### PR TITLE
Fix the cyclic dep fix

### DIFF
--- a/.changeset/tricky-olives-admire.md
+++ b/.changeset/tricky-olives-admire.md
@@ -2,4 +2,4 @@
 "@manypkg/get-packages": patch
 ---
 
-Ignore git-ignored files when glob searching for packages. This fixes an issue with package cycles.
+Ignore `node_modules` when glob searching for packages. This fixes an issue with package cycles.

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+!/__fixtures__/local-deps-cycle/packages/package-one/node_modules/
 dist/
 *.log
 .cache

--- a/__fixtures__/local-deps-cycle/package.json
+++ b/__fixtures__/local-deps-cycle/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@manypkg/local-deps-cycle-fixture",
+  "version": "1.0.0",
+  "workspaces": [
+    "packages/**"
+  ]
+}

--- a/__fixtures__/local-deps-cycle/packages/cyclic-dep/package.json
+++ b/__fixtures__/local-deps-cycle/packages/cyclic-dep/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@manypkg/cyclic-dep",
+  "version": "1.0.0"
+}

--- a/packages/get-packages/src/index.test.ts
+++ b/packages/get-packages/src/index.test.ts
@@ -91,6 +91,19 @@ let runTests = (getPackages: GetPackages) => {
       );
     }
   });
+
+  it("should not crash on cyclic deps", async () => {
+    const allPackages = await getPackages(f.copy("local-deps-cycle"));
+
+    if (allPackages.packages === null) {
+      return expect(allPackages.packages).not.toBeNull();
+    }
+
+    expect(allPackages.packages[0].packageJson.name).toEqual(
+      "@manypkg/cyclic-dep"
+    );
+    expect(allPackages.tool).toEqual("yarn");
+  });
 };
 
 describe("getPackages", () => {

--- a/packages/get-packages/src/index.ts
+++ b/packages/get-packages/src/index.ts
@@ -97,7 +97,7 @@ export async function getPackages(dir: string): Promise<Packages> {
     onlyDirectories: true,
     absolute: true,
     expandDirectories: false,
-    gitignore: true
+    ignore: ["**/node_modules"]
   });
 
   let pkgJsonsMissingNameField: Array<string> = [];
@@ -203,7 +203,7 @@ export function getPackagesSync(dir: string): Packages {
     onlyDirectories: true,
     absolute: true,
     expandDirectories: false,
-    gitignore: true
+    ignore: ["**/node_modules"]
   });
 
   let pkgJsonsMissingNameField: Array<string> = [];


### PR DESCRIPTION
Unfortunately, `gitignore` option gets resolved **after** globbing - whereas `ignore` patterns are taken into account when globbing.