### PR TITLE
Add --default-branch cli switch for INCORRECT_REPOSITORY_FIELD check

### DIFF
--- a/.changeset/little-gifts-tickle.md
+++ b/.changeset/little-gifts-tickle.md
@@ -1,0 +1,23 @@
+---
+"@manypkg/cli": minor
+---
+
+Add package.json#manypkg config object:
+
+```
+{
+  "manypkg": {}
+}
+```
+
+To support setting a default branch for the INCORRECT_REPOSITORY_FIELD check/fix, a new config option can be set:
+
+```
+{
+  "manypkg": {
+    "defaultBranch": "master"
+  }
+}
+```
+
+The default `defaultBranch` is `"master"`.

--- a/packages/cli/src/checks/INCORRECT_REPOSITORY_FIELD.ts
+++ b/packages/cli/src/checks/INCORRECT_REPOSITORY_FIELD.ts
@@ -14,7 +14,7 @@ type ErrorType = {
 
 export default makeCheck<ErrorType>({
   type: "all",
-  validate: (workspace, allWorkspaces, rootWorkspace) => {
+  validate: (workspace, allWorkspaces, rootWorkspace, options) => {
     let rootRepositoryField = (rootWorkspace.packageJson as any).repository;
 
     if (typeof rootRepositoryField === "string") {
@@ -43,17 +43,18 @@ export default makeCheck<ErrorType>({
             ];
           }
         } else {
-          // TODO: handle default branches that aren't master
           let correctRepositoryField = "";
 
           if (result.host === "github.com") {
-            correctRepositoryField = `${baseRepositoryUrl}/tree/master/${normalizePath(
+            correctRepositoryField = `${baseRepositoryUrl}/tree/${
+              options.defaultBranch
+            }/${normalizePath(
               path.relative(rootWorkspace.dir, workspace.dir)
             )}`;
           } else if (result.host === "dev.azure.com") {
             correctRepositoryField = `${baseRepositoryUrl}?path=${normalizePath(
               path.relative(rootWorkspace.dir, workspace.dir)
-            )}&version=GBmaster&_a=contents`;
+            )}&version=GB${options.defaultBranch}&_a=contents`;
           }
 
           let currentRepositoryField = (workspace.packageJson as any)

--- a/packages/cli/src/checks/__tests__/INCORRECT_REPOSITORY_FIELD.ts
+++ b/packages/cli/src/checks/__tests__/INCORRECT_REPOSITORY_FIELD.ts
@@ -1,12 +1,13 @@
 import path from "path";
 import check from "../INCORRECT_REPOSITORY_FIELD";
-import { getWS, getFakeWS } from "../../test-helpers";
+import { getWS, getFakeWS, getFakeString } from "../../test-helpers";
 
 describe("incorrect repository field", () => {
   describe("github", () => {
     it("should work", () => {
       let ws = getWS();
       let rootWorkspace = getFakeWS("root");
+      let defaultBranch = `b${getFakeString(5)}`;
 
       (rootWorkspace.packageJson as any).repository =
         "https://github.com/Thinkmill/manypkg";
@@ -15,27 +16,30 @@ describe("incorrect repository field", () => {
       workspace.dir = path.join(__dirname, "packages/no-repository-field");
       ws.set("depends-on-one", workspace);
       ws.set("root", rootWorkspace);
-      let errors = check.validate(workspace, ws, rootWorkspace);
+      let errors = check.validate(workspace, ws, rootWorkspace, {
+        defaultBranch
+      });
       expect(errors.map(({ workspace, ...x }: any) => x))
         .toMatchInlineSnapshot(`
                       Array [
                         Object {
-                          "correctRepositoryField": "https://github.com/Thinkmill/manypkg/tree/master/packages/no-repository-field",
+                          "correctRepositoryField": "https://github.com/Thinkmill/manypkg/tree/${defaultBranch}/packages/no-repository-field",
                           "currentRepositoryField": undefined,
                           "type": "INCORRECT_REPOSITORY_FIELD",
                         },
                       ]
                 `);
 
-      check.fix(errors[0]);
+      check.fix(errors[0], {});
 
       expect((workspace.packageJson as any).repository).toBe(
-        "https://github.com/Thinkmill/manypkg/tree/master/packages/no-repository-field"
+        `https://github.com/Thinkmill/manypkg/tree/${defaultBranch}/packages/no-repository-field`
       );
     });
     it("should fix root in a different format", () => {
       let ws = getWS();
       let rootWorkspace = getFakeWS("root");
+      let defaultBranch = `b${getFakeString(5)}`;
 
       (rootWorkspace.packageJson as any).repository =
         "https://github.com/Thinkmill/manypkg.git";
@@ -45,7 +49,9 @@ describe("incorrect repository field", () => {
       workspace.dir = path.join(__dirname, "packages/no-repository-field");
       ws.set("depends-on-one", workspace);
       ws.set("root", rootWorkspace);
-      let errors = check.validate(rootWorkspace, ws, rootWorkspace);
+      let errors = check.validate(rootWorkspace, ws, rootWorkspace, {
+        defaultBranch
+      });
       expect(errors.map(({ workspace, ...x }: any) => x))
         .toMatchInlineSnapshot(`
                       Array [
@@ -57,7 +63,7 @@ describe("incorrect repository field", () => {
                       ]
                 `);
 
-      check.fix(errors[0]);
+      check.fix(errors[0], {});
 
       expect((rootWorkspace.packageJson as any).repository).toBe(
         "https://github.com/Thinkmill/manypkg"
@@ -66,6 +72,7 @@ describe("incorrect repository field", () => {
     it("should do nothing if already in good format", () => {
       let ws = getWS();
       let rootWorkspace = getFakeWS("root");
+      let defaultBranch = `b${getFakeString(5)}`;
 
       (rootWorkspace.packageJson as any).repository =
         "https://github.com/Thinkmill/manypkg";
@@ -75,7 +82,9 @@ describe("incorrect repository field", () => {
       workspace.dir = path.join(__dirname, "packages/no-repository-field");
       ws.set("depends-on-one", workspace);
       ws.set("root", rootWorkspace);
-      let errors = check.validate(rootWorkspace, ws, rootWorkspace);
+      let errors = check.validate(rootWorkspace, ws, rootWorkspace, {
+        defaultBranch
+      });
       expect(errors.map(({ workspace, ...x }: any) => x)).toMatchInlineSnapshot(
         `Array []`
       );
@@ -90,6 +99,7 @@ describe("incorrect repository field", () => {
     it("should work", () => {
       let ws = getWS();
       let rootWorkspace = getFakeWS("root");
+      let defaultBranch = `b${getFakeString(5)}`;
 
       (rootWorkspace.packageJson as any).repository =
         "https://dev.azure.com/Thinkmill/monorepos/_git/manypkg";
@@ -98,27 +108,30 @@ describe("incorrect repository field", () => {
       workspace.dir = path.join(__dirname, "packages/no-repository-field");
       ws.set("depends-on-one", workspace);
       ws.set("root", rootWorkspace);
-      let errors = check.validate(workspace, ws, rootWorkspace);
+      let errors = check.validate(workspace, ws, rootWorkspace, {
+        defaultBranch
+      });
       expect(errors.map(({ workspace, ...x }: any) => x))
         .toMatchInlineSnapshot(`
                       Array [
                         Object {
-                          "correctRepositoryField": "https://dev.azure.com/Thinkmill/monorepos/_git/manypkg?path=packages/no-repository-field&version=GBmaster&_a=contents",
+                          "correctRepositoryField": "https://dev.azure.com/Thinkmill/monorepos/_git/manypkg?path=packages/no-repository-field&version=GB${defaultBranch}&_a=contents",
                           "currentRepositoryField": undefined,
                           "type": "INCORRECT_REPOSITORY_FIELD",
                         },
                       ]
                 `);
 
-      check.fix(errors[0]);
+      check.fix(errors[0], {});
 
       expect((workspace.packageJson as any).repository).toBe(
-        "https://dev.azure.com/Thinkmill/monorepos/_git/manypkg?path=packages/no-repository-field&version=GBmaster&_a=contents"
+        `https://dev.azure.com/Thinkmill/monorepos/_git/manypkg?path=packages/no-repository-field&version=GB${defaultBranch}&_a=contents`
       );
     });
     it("should fix root in a different format", () => {
       let ws = getWS();
       let rootWorkspace = getFakeWS("root");
+      let defaultBranch = `b${getFakeString(5)}`;
 
       (rootWorkspace.packageJson as any).repository =
         "https://Thinkmill@dev.azure.com/Thinkmill/monorepos/_git/manypkg";
@@ -128,7 +141,9 @@ describe("incorrect repository field", () => {
       workspace.dir = path.join(__dirname, "packages/no-repository-field");
       ws.set("depends-on-one", workspace);
       ws.set("root", rootWorkspace);
-      let errors = check.validate(rootWorkspace, ws, rootWorkspace);
+      let errors = check.validate(rootWorkspace, ws, rootWorkspace, {
+        defaultBranch
+      });
       expect(errors.map(({ workspace, ...x }: any) => x))
         .toMatchInlineSnapshot(`
                       Array [
@@ -140,7 +155,7 @@ describe("incorrect repository field", () => {
                       ]
                 `);
 
-      check.fix(errors[0]);
+      check.fix(errors[0], {});
 
       expect((rootWorkspace.packageJson as any).repository).toBe(
         "https://dev.azure.com/Thinkmill/monorepos/_git/manypkg"
@@ -149,6 +164,7 @@ describe("incorrect repository field", () => {
     it("should do nothing if already in good format", () => {
       let ws = getWS();
       let rootWorkspace = getFakeWS("root");
+      let defaultBranch = `b${getFakeString(5)}`;
 
       (rootWorkspace.packageJson as any).repository =
         "https://dev.azure.com/Thinkmill/monorepos/_git/manypkg";
@@ -158,7 +174,9 @@ describe("incorrect repository field", () => {
       workspace.dir = path.join(__dirname, "packages/no-repository-field");
       ws.set("depends-on-one", workspace);
       ws.set("root", rootWorkspace);
-      let errors = check.validate(rootWorkspace, ws, rootWorkspace);
+      let errors = check.validate(rootWorkspace, ws, rootWorkspace, {
+        defaultBranch
+      });
       expect(errors.map(({ workspace, ...x }: any) => x)).toMatchInlineSnapshot(
         `Array []`
       );

--- a/packages/cli/src/checks/__tests__/INTERNAL_MISMATCH.ts
+++ b/packages/cli/src/checks/__tests__/INTERNAL_MISMATCH.ts
@@ -11,7 +11,7 @@ describe("internal mismatch", () => {
       "pkg-1": "^1.0.0"
     };
     ws.set("depends-on-one", dependsOnOne);
-    let errors = makeCheck.validate(dependsOnOne, ws, rootWorkspace);
+    let errors = makeCheck.validate(dependsOnOne, ws, rootWorkspace, {});
     expect(errors.length).toEqual(0);
   });
   it("should error if internal version is not compatible", () => {
@@ -21,7 +21,7 @@ describe("internal mismatch", () => {
       "pkg-1": "^0.1.0"
     };
     ws.set("depends-on-one", dependsOnOne);
-    let errors = makeCheck.validate(dependsOnOne, ws, rootWorkspace);
+    let errors = makeCheck.validate(dependsOnOne, ws, rootWorkspace, {});
     expect(errors[0]).toMatchObject({
       type: "INTERNAL_MISMATCH",
       dependencyWorkspace: ws.get("pkg-1"),
@@ -43,7 +43,7 @@ describe("internal mismatch", () => {
       dependencyRange: "^0.1.0"
     };
 
-    let fixed = makeCheck.fix!(error);
+    let fixed = makeCheck.fix!(error, {});
     expect(fixed).toMatchObject({ requiresInstall: true });
     expect(workspace.packageJson.dependencies).toMatchObject({
       "pkg-1": "^1.0.0"
@@ -56,7 +56,7 @@ describe("internal mismatch", () => {
       "pkg-1": "^0.1.0"
     };
     ws.set("depends-on-one", dependsOnOne);
-    let errors = makeCheck.validate(dependsOnOne, ws, rootWorkspace);
+    let errors = makeCheck.validate(dependsOnOne, ws, rootWorkspace, {});
     expect(errors).toMatchInlineSnapshot(`
       Array [
         Object {

--- a/packages/cli/src/checks/__tests__/INVALID_DEV_AND_PEER_DEPENDENCY.ts
+++ b/packages/cli/src/checks/__tests__/INVALID_DEV_AND_PEER_DEPENDENCY.ts
@@ -15,7 +15,7 @@ describe("invalid dev and peer dependency", () => {
         "pkg-1": "^1.0.0"
       };
       ws.set("depends-on-one", dependsOnOne);
-      let errors = makeCheck.validate(dependsOnOne, ws, rootWorkspace);
+      let errors = makeCheck.validate(dependsOnOne, ws, rootWorkspace, {});
       expect(errors.length).toEqual(0);
     });
     it("should not error if the dependencies match", () => {
@@ -30,7 +30,7 @@ describe("invalid dev and peer dependency", () => {
         "pkg-1": "*"
       };
       ws.set("depends-on-one", dependsOnOne);
-      let errors = makeCheck.validate(dependsOnOne, ws, rootWorkspace);
+      let errors = makeCheck.validate(dependsOnOne, ws, rootWorkspace, {});
       expect(errors.length).toEqual(0);
     });
     it("should error if the devDependency is missing", () => {
@@ -41,7 +41,7 @@ describe("invalid dev and peer dependency", () => {
         "pkg-1": "^1.0.0"
       };
       ws.set("depends-on-one", dependsOnOne);
-      let errors = makeCheck.validate(dependsOnOne, ws, rootWorkspace);
+      let errors = makeCheck.validate(dependsOnOne, ws, rootWorkspace, {});
 
       expect(errors[0]).toMatchObject({
         type: "INVALID_DEV_AND_PEER_DEPENDENCY_RELATIONSHIP",
@@ -60,7 +60,7 @@ describe("invalid dev and peer dependency", () => {
       pkg1.packageJson.peerDependencies = {
         "external-dep": "^1.0.0"
       };
-      let errors = makeCheck.validate(pkg1, ws, rootWorkspace);
+      let errors = makeCheck.validate(pkg1, ws, rootWorkspace, {});
 
       expect(errors[0]).toMatchObject({
         type: "INVALID_DEV_AND_PEER_DEPENDENCY_RELATIONSHIP",
@@ -86,7 +86,7 @@ describe("invalid dev and peer dependency", () => {
       };
 
       ws.set("pkg-2", pkg2);
-      let errors = makeCheck.validate(pkg1, ws, rootWorkspace);
+      let errors = makeCheck.validate(pkg1, ws, rootWorkspace, {});
 
       expect(errors[0]).toMatchObject({
         type: "INVALID_DEV_AND_PEER_DEPENDENCY_RELATIONSHIP",
@@ -113,7 +113,7 @@ describe("invalid dev and peer dependency", () => {
       };
 
       ws.set("pkg-2", pkg2);
-      let errors = makeCheck.validate(pkg1, ws, rootWorkspace);
+      let errors = makeCheck.validate(pkg1, ws, rootWorkspace, {});
 
       expect(errors[0]).not.toMatchObject({
         type: "INVALID_DEV_AND_PEER_DEPENDENCY_RELATIONSHIP",
@@ -131,10 +131,10 @@ describe("invalid dev and peer dependency", () => {
     pkg1.packageJson.peerDependencies = {
       "external-dep": "^1.0.0"
     };
-    let errors = makeCheck.validate(pkg1, ws, rootWorkspace);
+    let errors = makeCheck.validate(pkg1, ws, rootWorkspace, {});
     let error = errors[0]!;
 
-    let fixed = makeCheck.fix!(error);
+    let fixed = makeCheck.fix!(error, {});
     expect(fixed).toMatchObject({ requiresInstall: true });
     expect(pkg1.packageJson.devDependencies).toMatchObject({
       "external-dep": "^1.0.0"
@@ -150,7 +150,7 @@ describe("invalid dev and peer dependency", () => {
     pkg1.packageJson.devDependencies = {
       "external-dep": "^1.1.0"
     };
-    let errors = makeCheck.validate(pkg1, ws, rootWorkspace);
+    let errors = makeCheck.validate(pkg1, ws, rootWorkspace, {});
     expect(errors).toHaveLength(0);
   });
 });

--- a/packages/cli/src/checks/utils.ts
+++ b/packages/cli/src/checks/utils.ts
@@ -14,24 +14,36 @@ export const DEPENDENCY_TYPES = [
   "peerDependencies"
 ] as const;
 
+export type Options = { defaultBranch?: string };
+
 type RootCheck<ErrorType> = {
   type: "root";
   validate: (
     rootPackage: Package,
-    allPackages: Map<string, Package>
+    allPackages: Map<string, Package>,
+    rootWorkspace: Package,
+    options: Options
   ) => ErrorType[];
-  fix?: (error: ErrorType) => void | { requiresInstall: boolean };
-  print: (error: ErrorType) => string;
+  fix?: (
+    error: ErrorType,
+    options: Options
+  ) => void | { requiresInstall: boolean };
+  print: (error: ErrorType, options: Options) => string;
 };
 
 type RootCheckWithFix<ErrorType> = {
   type: "root";
   validate: (
     rootPackage: Package,
-    allPackages: Map<string, Package>
+    allPackages: Map<string, Package>,
+    rootWorkspace: Package,
+    options: Options
   ) => ErrorType[];
-  fix: (error: ErrorType) => void | { requiresInstall: boolean };
-  print: (error: ErrorType) => string;
+  fix: (
+    error: ErrorType,
+    options: Options
+  ) => void | { requiresInstall: boolean };
+  print: (error: ErrorType, options: Options) => string;
 };
 
 type AllCheck<ErrorType> = {
@@ -39,10 +51,14 @@ type AllCheck<ErrorType> = {
   validate: (
     workspace: Package,
     allWorkspaces: Map<string, Package>,
-    rootWorkspace: Package
+    rootWorkspace: Package,
+    options: Options
   ) => ErrorType[];
-  fix?: (error: ErrorType) => void | { requiresInstall: boolean };
-  print: (error: ErrorType) => string;
+  fix?: (
+    error: ErrorType,
+    options: Options
+  ) => void | { requiresInstall: boolean };
+  print: (error: ErrorType, options: Options) => string;
 };
 
 type AllCheckWithFix<ErrorType> = {
@@ -50,10 +66,14 @@ type AllCheckWithFix<ErrorType> = {
   validate: (
     workspace: Package,
     allWorkspaces: Map<string, Package>,
-    rootWorkspace: Package
+    rootWorkspace: Package,
+    options: Options
   ) => ErrorType[];
-  fix: (error: ErrorType) => void | { requiresInstall: boolean };
-  print: (error: ErrorType) => string;
+  fix: (
+    error: ErrorType,
+    options: Options
+  ) => void | { requiresInstall: boolean };
+  print: (error: ErrorType, options: Options) => string;
 };
 
 export type Check<ErrorType> =

--- a/packages/cli/src/test-helpers.ts
+++ b/packages/cli/src/test-helpers.ts
@@ -5,6 +5,7 @@
 // Who can say? ¯\_(ツ)_/¯
 
 import { Package } from "@manypkg/get-packages";
+import crypto from "crypto";
 
 export let getFakeWS = (
   name: string = "pkg-1",
@@ -23,4 +24,16 @@ export let getWS = (): Map<string, Package> => {
   let pkg = new Map();
   pkg.set("pkg-1", getFakeWS());
   return pkg;
+};
+
+export let getFakeString = (length: number): string => {
+  return (
+    crypto
+      // converting to hex doubles the length, so we request half as many bytes
+      .randomBytes(Math.ceil(length / 2))
+      .toString("hex")
+      // if length is odd, Math.ceil() will have requested too many bytes, so we
+      // chop them off by only grabbing `length` characters
+      .substring(-length)
+  );
 };


### PR DESCRIPTION
My repositories use `main` as the default branch, which causes `manypkg check` to incorrectly error with:

```
$ yarn manypkg check
...
☔️ error @example/button has a repository field of "https://github.com/example/repo/tree/main/button" when it should be "https://github.com/example/repo/tree/master/button"
error Command failed with exit code 1.
```

With this new cli swich, I can successfully execute:

```
$ yarn manypkg check --default-branch=main
...
✨  Done in 0.15s.
```