### PR TITLE
Add missing license fields

### DIFF
--- a/.changeset/rude-lizards-rule.md
+++ b/.changeset/rude-lizards-rule.md
@@ -1,0 +1,6 @@
+---
+"@manypkg/gatsby-source-workspace": patch
+"@manypkg/get-packages": patch
+---
+
+Add missing license field

--- a/packages/gatsby-source-workspace/package.json
+++ b/packages/gatsby-source-workspace/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@manypkg/gatsby-source-workspace",
   "version": "0.4.0",
+  "license": "MIT",
   "peerDependencies": {
     "gatsby": "^2.15.28"
   },

--- a/packages/get-packages/package.json
+++ b/packages/get-packages/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@manypkg/get-packages",
   "version": "1.1.0",
+  "license": "MIT",
   "main": "dist/get-packages.cjs.js",
   "dependencies": {
     "@babel/runtime": "^7.5.5",


### PR DESCRIPTION
Running an audit on one of my projects flagged this field as missing for these packages.