### PR TITLE
chore: upgrade caniuse-lite db

### DIFF
--- a/packages/cli/src/__snapshots__/run.test.ts.snap
+++ b/packages/cli/src/__snapshots__/run.test.ts.snap
@@ -1,8 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Run command should execute "package start" and exit with 1: stderr 1`] = `
-"Browserslist: caniuse-lite is outdated. Please run next command \`yarn upgrade\`
-☔️ error an identifier must only match a single package but \\"package\\" matches the following packages: 
+"☔️ error an identifier must only match a single package but \\"package\\" matches the following packages: 
 ☔️ error @manypkg/basic-fixture-pkg-one
 ☔️ error @manypkg/basic-fixture-pkg-two
 "
@@ -11,8 +10,7 @@ exports[`Run command should execute "package start" and exit with 1: stderr 1`] 
 exports[`Run command should execute "package start" and exit with 1: stdout 1`] = `""`;
 
 exports[`Run command should execute "package-one start" and exit with 0: stderr 1`] = `
-"Browserslist: caniuse-lite is outdated. Please run next command \`yarn upgrade\`
-warning package.json: No license field
+"warning package.json: No license field
 warning ../../package.json: No license field
 "
 `;
@@ -24,8 +22,7 @@ hello start
 `;
 
 exports[`Run command should execute "package-one test" and exit with 0: stderr 1`] = `
-"Browserslist: caniuse-lite is outdated. Please run next command \`yarn upgrade\`
-warning package.json: No license field
+"warning package.json: No license field
 warning ../../package.json: No license field
 "
 `;
@@ -37,16 +34,14 @@ testing
 `;
 
 exports[`Run command should execute "package-three start" and exit with 1: stderr 1`] = `
-"Browserslist: caniuse-lite is outdated. Please run next command \`yarn upgrade\`
-☔️ error No matching packages found
+"☔️ error No matching packages found
 "
 `;
 
 exports[`Run command should execute "package-three start" and exit with 1: stdout 1`] = `""`;
 
 exports[`Run command should execute "package-two something" and exit with 1: stderr 1`] = `
-"Browserslist: caniuse-lite is outdated. Please run next command \`yarn upgrade\`
-warning package.json: No license field
+"warning package.json: No license field
 warning ../../package.json: No license field
 error Command \\"something\\" not found.
 "
@@ -58,8 +53,7 @@ exports[`Run command should execute "package-two something" and exit with 1: std
 `;
 
 exports[`Run command should execute "package-two start" and exit with 0: stderr 1`] = `
-"Browserslist: caniuse-lite is outdated. Please run next command \`yarn upgrade\`
-warning package.json: No license field
+"warning package.json: No license field
 warning ../../package.json: No license field
 "
 `;
@@ -71,8 +65,7 @@ hello start
 `;
 
 exports[`Run command should execute "pkg-one start" and exit with 0: stderr 1`] = `
-"Browserslist: caniuse-lite is outdated. Please run next command \`yarn upgrade\`
-warning package.json: No license field
+"warning package.json: No license field
 warning ../../package.json: No license field
 "
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3590,15 +3590,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30000980, caniuse-lite@^1.0.30000989:
-  version "1.0.30000998"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000998.tgz#7227a8046841e7d01e156ae7227a504d065f6744"
-  integrity sha512-8Tj5sPZR9kMHeDD9SZXIVr5m9ofufLLCG2Y4QwQrH18GIwG+kCc+zYdlR036ZRkuKjVVetyxeAgGA1xF7XdmzQ==
-
-caniuse-lite@^1.0.30000984:
-  version "1.0.30000989"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000989.tgz#b9193e293ccf7e4426c5245134b8f2a56c0ac4b9"
-  integrity sha512-vrMcvSuMz16YY6GSVZ0dWDTJP8jqk3iFQ/Aq5iqblPwxSVVZI+zxDyTX0VPqtQsDnfdrBDcsmhgTEOh5R8Lbpw==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30000980, caniuse-lite@^1.0.30000984, caniuse-lite@^1.0.30000989:
+  version "1.0.30001168"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001168.tgz#6fcd098c139d003b9bd484cbb9ca26cb89907f9a"
+  integrity sha512-P2zmX7swIXKu+GMMR01TWa4csIKELTNnZKc+f1CjebmZJQtTAEXmpQSoKVJVVcvPGAA0TEYTOUp3VehavZSFPQ==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
I'm working on something else in the codebase and noticed that a lot of the snapshots for `run.test` have embedded `Browserslist` errors. This PR upgrades the `caniuse-lite` db and updates the snapshots to keep the snapshot messages directly relevant to the packages.