### PR TITLE
feat(cli): add exact pkg/dir name matching for run command

### DIFF
--- a/.changeset/dirty-phones-tell.md
+++ b/.changeset/dirty-phones-tell.md
@@ -1,0 +1,17 @@
+---
+"@manypkg/cli": minor
+---
+
+Added the ability to use the exact package or directory name to target a package that is a substring of another with for the `run` command:
+
+If packages exist at `packages/pkg-a` and `packages/pkg-a-1`, target `pkg-a` using the exact directory name:
+
+```bash
+yarn manypkg run packages/pkg-a
+```
+
+If packages are named `@project/package-a` and `@project/package-a-1`, target `package-a` using the exact package name:
+
+```bash
+yarn manypkg run @project/package-a
+```

--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ yarn manypkg run package start
 yarn manypkg run pkg start
 ```
 
+In order to target a package with a name that is a substring of another (for example, `@project/package-a` at `packages/pkg-a` and `@project/package-a-1` at `packages/pkg-a-1`), use the exact package or directory name:
+
+```bash
+yarn manypkg run @project/package-a start
+yarn manypkg run packages/pkg-a start
+```
+
 ### `manypkg exec <cli command>`
 
 `manypkg exec` executes a command for all packages within a monorepo.

--- a/__fixtures__/basic-with-scripts/packages/package-two-one/package.json
+++ b/__fixtures__/basic-with-scripts/packages/package-two-one/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@manypkg/basic-fixture-pkg-two-one",
+  "version": "1.0.0",
+  "scripts": {
+    "start": "echo hello start",
+    "test": "echo testing"
+  }
+}

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -76,3 +76,10 @@ The following wouldn't work though because the `package` and `pkg` aren't unique
 yarn manypkg run package start
 yarn manypkg run pkg start
 ```
+
+In order to target a package with a name that is a substring of another (`@project/package-a` at `packages/pkg-a` and `@project/package-a-1` at `packages/pkg-a-1`), use the exact package or directory name:
+
+```bash
+yarn manypkg run @project/package-a start
+yarn manypkg run packages/pkg-a start
+```

--- a/packages/cli/src/__snapshots__/run.test.ts.snap
+++ b/packages/cli/src/__snapshots__/run.test.ts.snap
@@ -1,5 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Run command should execute "@manypkg/basic-fixture-pkg-two start" and exit with 0: stderr 1`] = `
+"Browserslist: caniuse-lite is outdated. Please run next command \`yarn upgrade\`
+warning package.json: No license field
+warning ../../package.json: No license field
+"
+`;
+
+exports[`Run command should execute "@manypkg/basic-fixture-pkg-two start" and exit with 0: stdout 1`] = `
+"$ echo hello start
+hello start
+"
+`;
+
 exports[`Run command should execute "package start" and exit with 1: stderr 1`] = `
 "Browserslist: caniuse-lite is outdated. Please run next command \`yarn upgrade\`
 ☔️ error an identifier must only match a single package but \\"package\\" matches the following packages: 
@@ -76,6 +89,19 @@ warning ../../package.json: No license field
 `;
 
 exports[`Run command should execute "package-two-one start" and exit with 0: stdout 1`] = `
+"$ echo hello start
+hello start
+"
+`;
+
+exports[`Run command should execute "packages/package-two start" and exit with 0: stderr 1`] = `
+"Browserslist: caniuse-lite is outdated. Please run next command \`yarn upgrade\`
+warning package.json: No license field
+warning ../../package.json: No license field
+"
+`;
+
+exports[`Run command should execute "packages/package-two start" and exit with 0: stdout 1`] = `
 "$ echo hello start
 hello start
 "

--- a/packages/cli/src/__snapshots__/run.test.ts.snap
+++ b/packages/cli/src/__snapshots__/run.test.ts.snap
@@ -5,6 +5,7 @@ exports[`Run command should execute "package start" and exit with 1: stderr 1`] 
 ☔️ error an identifier must only match a single package but \\"package\\" matches the following packages: 
 ☔️ error @manypkg/basic-fixture-pkg-one
 ☔️ error @manypkg/basic-fixture-pkg-two
+☔️ error @manypkg/basic-fixture-pkg-two-one
 "
 `;
 
@@ -44,7 +45,17 @@ exports[`Run command should execute "package-three start" and exit with 1: stder
 
 exports[`Run command should execute "package-three start" and exit with 1: stdout 1`] = `""`;
 
-exports[`Run command should execute "package-two something" and exit with 1: stderr 1`] = `
+exports[`Run command should execute "package-two start" and exit with 1: stderr 1`] = `
+"Browserslist: caniuse-lite is outdated. Please run next command \`yarn upgrade\`
+☔️ error an identifier must only match a single package but \\"package-two\\" matches the following packages: 
+☔️ error @manypkg/basic-fixture-pkg-two
+☔️ error @manypkg/basic-fixture-pkg-two-one
+"
+`;
+
+exports[`Run command should execute "package-two start" and exit with 1: stdout 1`] = `""`;
+
+exports[`Run command should execute "package-two-one something" and exit with 1: stderr 1`] = `
 "Browserslist: caniuse-lite is outdated. Please run next command \`yarn upgrade\`
 warning package.json: No license field
 warning ../../package.json: No license field
@@ -52,19 +63,19 @@ error Command \\"something\\" not found.
 "
 `;
 
-exports[`Run command should execute "package-two something" and exit with 1: stdout 1`] = `
+exports[`Run command should execute "package-two-one something" and exit with 1: stdout 1`] = `
 "info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
 "
 `;
 
-exports[`Run command should execute "package-two start" and exit with 0: stderr 1`] = `
+exports[`Run command should execute "package-two-one start" and exit with 0: stderr 1`] = `
 "Browserslist: caniuse-lite is outdated. Please run next command \`yarn upgrade\`
 warning package.json: No license field
 warning ../../package.json: No license field
 "
 `;
 
-exports[`Run command should execute "package-two start" and exit with 0: stdout 1`] = `
+exports[`Run command should execute "package-two-one start" and exit with 0: stdout 1`] = `
 "$ echo hello start
 hello start
 "
@@ -83,14 +94,24 @@ hello start
 "
 `;
 
-exports[`Run command should execute "pkg-two start" and exit with 0: stderr 1`] = `
+exports[`Run command should execute "pkg-two start" and exit with 1: stderr 1`] = `
+"Browserslist: caniuse-lite is outdated. Please run next command \`yarn upgrade\`
+☔️ error an identifier must only match a single package but \\"pkg-two\\" matches the following packages: 
+☔️ error @manypkg/basic-fixture-pkg-two
+☔️ error @manypkg/basic-fixture-pkg-two-one
+"
+`;
+
+exports[`Run command should execute "pkg-two start" and exit with 1: stdout 1`] = `""`;
+
+exports[`Run command should execute "pkg-two-one start" and exit with 0: stderr 1`] = `
 "Browserslist: caniuse-lite is outdated. Please run next command \`yarn upgrade\`
 warning package.json: No license field
 warning ../../package.json: No license field
 "
 `;
 
-exports[`Run command should execute "pkg-two start" and exit with 0: stdout 1`] = `
+exports[`Run command should execute "pkg-two-one start" and exit with 0: stdout 1`] = `
 "$ echo hello start
 hello start
 "

--- a/packages/cli/src/__snapshots__/run.test.ts.snap
+++ b/packages/cli/src/__snapshots__/run.test.ts.snap
@@ -82,3 +82,16 @@ exports[`Run command should execute "pkg-one start" and exit with 0: stdout 1`] 
 hello start
 "
 `;
+
+exports[`Run command should execute "pkg-two start" and exit with 0: stderr 1`] = `
+"Browserslist: caniuse-lite is outdated. Please run next command \`yarn upgrade\`
+warning package.json: No license field
+warning ../../package.json: No license field
+"
+`;
+
+exports[`Run command should execute "pkg-two start" and exit with 0: stdout 1`] = `
+"$ echo hello start
+hello start
+"
+`;

--- a/packages/cli/src/run.test.ts
+++ b/packages/cli/src/run.test.ts
@@ -9,6 +9,7 @@ describe("Run command", () => {
   it.each([
     ["package-one", "start", 0],
     ["package-one", "test", 0],
+    ["packages/package-two", "start", 0],
     ["package-two-one", "start", 0],
     ["package", "start", 1],
     ["package-two", "start", 1],
@@ -16,6 +17,7 @@ describe("Run command", () => {
     ["package-three", "start", 1],
     ["pkg-one", "start", 0],
     ["pkg-two", "start", 1],
+    ["@manypkg/basic-fixture-pkg-two", "start", 0],
     ["pkg-two-one", "start", 0]
     // @ts-ignore
   ])(

--- a/packages/cli/src/run.test.ts
+++ b/packages/cli/src/run.test.ts
@@ -9,12 +9,14 @@ describe("Run command", () => {
   it.each([
     ["package-one", "start", 0],
     ["package-one", "test", 0],
-    ["package-two", "start", 0],
+    ["package-two-one", "start", 0],
     ["package", "start", 1],
-    ["package-two", "something", 1],
+    ["package-two", "start", 1],
+    ["package-two-one", "something", 1],
     ["package-three", "start", 1],
     ["pkg-one", "start", 0],
-    ["pkg-two", "start", 0]
+    ["pkg-two", "start", 1],
+    ["pkg-two-one", "start", 0]
     // @ts-ignore
   ])(
     'should execute "%s %s" and exit with %i',

--- a/packages/cli/src/run.test.ts
+++ b/packages/cli/src/run.test.ts
@@ -13,7 +13,8 @@ describe("Run command", () => {
     ["package", "start", 1],
     ["package-two", "something", 1],
     ["package-three", "start", 1],
-    ["pkg-one", "start", 0]
+    ["pkg-one", "start", 0],
+    ["pkg-two", "start", 0]
     // @ts-ignore
   ])(
     'should execute "%s %s" and exit with %i',

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -6,6 +6,22 @@ import { ExitError } from "./errors";
 
 export async function runCmd(args: string[], cwd: string) {
   let { packages, root } = await getPackages(cwd);
+
+  const exactMatchingPackage = packages.find(pkg => {
+    return (
+      pkg.packageJson.name === args[0] ||
+      path.relative(root.dir, pkg.dir) === args[0]
+    );
+  });
+
+  if (exactMatchingPackage) {
+    const { code } = await spawn("yarn", args.slice(1), {
+      cwd: exactMatchingPackage.dir,
+      stdio: "inherit"
+    });
+    throw new ExitError(code);
+  }
+
   const matchingPackages = packages.filter(pkg => {
     return (
       pkg.packageJson.name.includes(args[0]) ||


### PR DESCRIPTION
This PR closes #82 by adding functionality for targeting a project using the exact package or directory name:

`@project/package-a` at `packages/pkg-a`
`@project/package-a-1` at `packages/pkg-a-1`

```bash
yarn manypkg run @project/package-a start
yarn manypkg run packages/pkg-a
```