### PR TITLE
feat(cli): check peer dependencies in root package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ dist/
 .cache
 public
 scratchings.js
+
+# IDEs
+.idea

--- a/packages/cli/src/checks/__tests__/INVALID_DEV_AND_PEER_DEPENDENCY.ts
+++ b/packages/cli/src/checks/__tests__/INVALID_DEV_AND_PEER_DEPENDENCY.ts
@@ -181,4 +181,19 @@ describe("invalid dev and peer dependency", () => {
     let errors = makeCheck.validate(pkg1, ws, rootWorkspace, {});
     expect(errors).toHaveLength(0);
   });
+
+  it("should work when peer dependency is in root dependency", () => {
+    let ws = getWS();
+    let pkg1 = ws.get("pkg-1")!;
+
+    pkg1.packageJson.peerDependencies = {
+      "external-dep": "^1.0.0"
+    };
+    rootWorkspace.packageJson.dependencies = {
+      "external-dep": "^1.0.0"
+    };
+
+    let errors = makeCheck.validate(pkg1, ws, rootWorkspace, {});
+    expect(errors).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
Closes #88

The command `manypkg check` will check for **dev** or **root** dependencies when validating **peerDependencies**.

I had the same problem discussed in #88 when testing one package that depends on another package with react/react-dom deps. The test will fail saying that you have multiple versions of react.