### PR TITLE
bug(get-packages): vulnerability in globby dependency

### DIFF
--- a/.changeset/dirty-dots-relate.md
+++ b/.changeset/dirty-dots-relate.md
@@ -1,0 +1,6 @@
+---
+"@manypkg/get-packages": patch
+"@manypkg/cli": patch
+---
+
+Bumping dependency on globby@^12.0.1 to fix npm audit vulnerability

--- a/packages/get-packages/package.json
+++ b/packages/get-packages/package.json
@@ -7,7 +7,7 @@
     "@babel/runtime": "^7.5.5",
     "@manypkg/find-root": "^1.1.0",
     "fs-extra": "^8.1.0",
-    "globby": "^11.0.0",
+    "globby": "^12.0.1",
     "read-yaml-file": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Closes #105 

The current `globby@^11.0.0` dependency has RegExp denial of service vulnerabilties

![image](https://user-images.githubusercontent.com/155616/130477932-2c09131c-63ad-46b4-b33b-79c540548c52.png)

This PR bumps to the patched version of `globby@^12.0.1`.