### PR TITLE
chore: incorrect type defs

### DIFF
--- a/packages/get-packages/package.json
+++ b/packages/get-packages/package.json
@@ -5,8 +5,8 @@
   "main": "dist/get-packages.cjs.js",
   "dependencies": {
     "@babel/runtime": "^7.5.5",
-    "@manypkg/find-root": "^1.1.0",
     "@changesets/types": "^4.0.1",
+    "@manypkg/find-root": "^1.1.0",
     "fs-extra": "^8.1.0",
     "globby": "^11.0.0",
     "read-yaml-file": "^1.1.0"

--- a/packages/get-packages/package.json
+++ b/packages/get-packages/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@babel/runtime": "^7.5.5",
     "@manypkg/find-root": "^1.1.0",
-    "@changesets/types": "*",
+    "@changesets/types": "^4.0.1",
     "fs-extra": "^8.1.0",
     "globby": "^11.0.0",
     "read-yaml-file": "^1.1.0"

--- a/packages/get-packages/package.json
+++ b/packages/get-packages/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@babel/runtime": "^7.5.5",
     "@manypkg/find-root": "^1.1.0",
+    "@changesets/types": "*",
     "fs-extra": "^8.1.0",
     "globby": "^11.0.0",
     "read-yaml-file": "^1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1453,6 +1453,11 @@
   resolved "https://registry.yarnpkg.com/@changesets/types/-/types-0.4.0.tgz#3413badb2c3904357a36268cb9f8c7e0afc3a804"
   integrity sha512-TclHHKDVYQ8rJGZgVeWiF7c91yWzTTWdPagltgutelGu/Psup5PQlUq6svx7S8suj+jXcaE34yEEsfIvzXXB2Q==
 
+"@changesets/types@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@changesets/types/-/types-4.0.1.tgz#85cf3cc32baff0691112d9d15fc21fbe022c9f0a"
+  integrity sha512-zVfv752D8K2tjyFmxU/vnntQ+dPu+9NupOSguA/2Zuym4tVxRh0ylArgKZ1bOAi2eXfGlZMxJU/kj7uCSI15RQ==
+
 "@cnakazawa/watch@^1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@cnakazawa/watch/-/watch-1.0.3.tgz#099139eaec7ebf07a27c1786a3ff64f39464d2ef"


### PR DESCRIPTION
This package imports a type from a file not defined in the package.

https://github.com/Thinkmill/manypkg/blob/24cf58240d8312c050c17708fb0b7e8aad78d21b/packages/get-packages/src/index.ts#L9

May I suggest including `depcheck` to avoid this in the future?