### PR TITLE
Change external mismatch check & fix to most common

### DIFF
--- a/packages/cli/src/checks/EXTERNAL_MISMATCH.ts
+++ b/packages/cli/src/checks/EXTERNAL_MISMATCH.ts
@@ -1,6 +1,6 @@
 import {
   makeCheck,
-  getHighestExternalRanges,
+  getMostCommonRangeMap,
   NORMAL_DEPENDENCY_TYPES
 } from "./utils";
 import { Package } from "@manypkg/get-packages";
@@ -11,23 +11,23 @@ type ErrorType = {
   workspace: Package;
   dependencyName: string;
   dependencyRange: string;
-  highestDependencyRange: string;
+  mostCommonDependencyRange: string;
 };
 
 export default makeCheck<ErrorType>({
   validate: (workspace, allWorkspace) => {
     let errors: ErrorType[] = [];
-    let highestExternalRanges = getHighestExternalRanges(allWorkspace);
+    let mostCommonRangeMap = getMostCommonRangeMap(allWorkspace);
     for (let depType of NORMAL_DEPENDENCY_TYPES) {
       let deps = workspace.packageJson[depType];
 
       if (deps) {
         for (let depName in deps) {
           let range = deps[depName];
-          let highestRange = highestExternalRanges.get(depName);
+          let mostCommonRange = mostCommonRangeMap.get(depName);
           if (
-            highestRange !== undefined &&
-            highestRange !== range &&
+            mostCommonRange !== undefined &&
+            mostCommonRange !== range &&
             validRange(range)
           ) {
             errors.push({
@@ -35,7 +35,7 @@ export default makeCheck<ErrorType>({
               workspace,
               dependencyName: depName,
               dependencyRange: range,
-              highestDependencyRange: highestRange
+              mostCommonDependencyRange: mostCommonRange
             });
           }
         }
@@ -47,12 +47,12 @@ export default makeCheck<ErrorType>({
     for (let depType of NORMAL_DEPENDENCY_TYPES) {
       let deps = error.workspace.packageJson[depType];
       if (deps && deps[error.dependencyName]) {
-        deps[error.dependencyName] = error.highestDependencyRange;
+        deps[error.dependencyName] = error.mostCommonDependencyRange;
       }
     }
     return { requiresInstall: true };
   },
   print: error =>
-    `${error.workspace.packageJson.name} has a dependency on ${error.dependencyName}@${error.dependencyRange} but the highest range in the repo is ${error.highestDependencyRange}, the range should be set to ${error.highestDependencyRange}`,
+    `${error.workspace.packageJson.name} has a dependency on ${error.dependencyName}@${error.dependencyRange} but the most common range in the repo is ${error.mostCommonDependencyRange}, the range should be set to ${error.mostCommonDependencyRange}`,
   type: "all"
 });

--- a/packages/cli/src/checks/INVALID_DEV_AND_PEER_DEPENDENCY_RELATIONSHIP.ts
+++ b/packages/cli/src/checks/INVALID_DEV_AND_PEER_DEPENDENCY_RELATIONSHIP.ts
@@ -1,4 +1,4 @@
-import { makeCheck, getHighestExternalRanges } from "./utils";
+import { makeCheck, getMostCommonRangeMap } from "./utils";
 import { Package } from "@manypkg/get-packages";
 import { upperBoundOfRangeAWithinBoundsOfB } from "sembear";
 import semver from "semver";
@@ -21,7 +21,7 @@ export default makeCheck<ErrorType>({
     if (peerDeps) {
       for (let depName in peerDeps) {
         if (!devDeps[depName]) {
-          let highestRanges = getHighestExternalRanges(allWorkspaces);
+          let highestRanges = getMostCommonRangeMap(allWorkspaces);
           let idealDevVersion = highestRanges.get(depName);
           let isInternalDependency = allWorkspaces.has(depName);
           if (isInternalDependency) {
@@ -48,7 +48,7 @@ export default makeCheck<ErrorType>({
             peerDeps[depName]
           )
         ) {
-          let highestRanges = getHighestExternalRanges(allWorkspaces);
+          let highestRanges = getMostCommonRangeMap(allWorkspaces);
           let idealDevVersion = highestRanges.get(depName);
           if (idealDevVersion === undefined) {
             idealDevVersion = peerDeps[depName];

--- a/packages/cli/src/checks/__tests__/EXTERNAL_MISMATCH.ts
+++ b/packages/cli/src/checks/__tests__/EXTERNAL_MISMATCH.ts
@@ -24,7 +24,7 @@ it("should error if the ranges are valid and they are not equal", () => {
       Object {
         "dependencyName": "something",
         "dependencyRange": "1.0.0",
-        "highestDependencyRange": "2.0.0",
+        "mostCommonDependencyRange": "2.0.0",
         "type": "EXTERNAL_MISMATCH",
         "workspace": Object {
           "dir": "some/fake/dir/pkg-1",
@@ -39,6 +39,127 @@ it("should error if the ranges are valid and they are not equal", () => {
       },
     ]
   `);
+});
+
+it("should error and return the correct mostCommonDependencyRange when the ranges are valid, they are not equal and there are more than 2", () => {
+  let ws = getWS();
+
+  ws.get("pkg-1")!.packageJson.dependencies = { something: "1.0.0" };
+
+  let pkg2 = getFakeWS("pkg-2");
+  pkg2.packageJson.dependencies = {
+    something: "2.0.0"
+  };
+  ws.set("pkg-2", pkg2);
+
+  let pkg3 = getFakeWS("pkg-3");
+  pkg3.packageJson.dependencies = {
+    something: "1.0.0"
+  };
+
+  ws.set("pkg-3", pkg3);
+  let errors = internalMismatch.validate(
+    ws.get("pkg-1")!,
+    ws,
+    rootWorkspace,
+    {}
+  );
+  expect(errors.length).toEqual(0);
+
+  errors = internalMismatch.validate(pkg2, ws, rootWorkspace, {});
+  expect(errors.length).toEqual(1);
+  expect(errors).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "dependencyName": "something",
+        "dependencyRange": "2.0.0",
+        "mostCommonDependencyRange": "1.0.0",
+        "type": "EXTERNAL_MISMATCH",
+        "workspace": Object {
+          "dir": "some/fake/dir/pkg-2",
+          "packageJson": Object {
+            "dependencies": Object {
+              "something": "2.0.0",
+            },
+            "name": "pkg-2",
+            "version": "1.0.0",
+          },
+        },
+      },
+    ]
+  `);
+});
+
+it("should error and return the correct mostCommonDependencyRange when the ranges are valid, but everything wants a different version", () => {
+  let ws = getWS();
+
+  ws.get("pkg-1")!.packageJson.dependencies = { something: "1.0.0" };
+
+  let pkg2 = getFakeWS("pkg-2");
+  pkg2.packageJson.dependencies = {
+    something: "2.0.0"
+  };
+  ws.set("pkg-2", pkg2);
+
+  let pkg3 = getFakeWS("pkg-3");
+  pkg3.packageJson.dependencies = {
+    something: "3.0.0"
+  };
+
+  ws.set("pkg-3", pkg3);
+  let errors = internalMismatch.validate(
+    ws.get("pkg-1")!,
+    ws,
+    rootWorkspace,
+    {}
+  );
+  expect(errors.length).toEqual(1);
+  expect(errors).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "dependencyName": "something",
+        "dependencyRange": "1.0.0",
+        "mostCommonDependencyRange": "3.0.0",
+        "type": "EXTERNAL_MISMATCH",
+        "workspace": Object {
+          "dir": "some/fake/dir/pkg-1",
+          "packageJson": Object {
+            "dependencies": Object {
+              "something": "1.0.0",
+            },
+            "name": "pkg-1",
+            "version": "1.0.0",
+          },
+        },
+      },
+    ]
+  `);
+
+  errors = internalMismatch.validate(pkg2, ws, rootWorkspace, {});
+  expect(errors.length).toEqual(1);
+  expect(errors).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "dependencyName": "something",
+        "dependencyRange": "2.0.0",
+        "mostCommonDependencyRange": "3.0.0",
+        "type": "EXTERNAL_MISMATCH",
+        "workspace": Object {
+          "dir": "some/fake/dir/pkg-2",
+          "packageJson": Object {
+            "dependencies": Object {
+              "something": "2.0.0",
+            },
+            "name": "pkg-2",
+            "version": "1.0.0",
+          },
+        },
+      },
+    ]
+  `);
+
+  errors = internalMismatch.validate(pkg3, ws, rootWorkspace, {});
+  expect(errors.length).toEqual(0);
 });
 
 it("should not error if the value is not a valid semver range", () => {


### PR DESCRIPTION
fixes #117

When a developer adds a new dependency, npm/yarn will add the
newest version of the dependency. We want manypkg to fix that newest
version to the most commonly used version in the repo, since it is
unlikely that a developer adding a new dependency to a package also
intends to update the whole repo.

If the dependency range for a dependency all occur once, it will
fix to the highest version.