### PR TITLE
Update package.json to include the repository

### DIFF
--- a/packages/find-root/package.json
+++ b/packages/find-root/package.json
@@ -10,6 +10,11 @@
     "find-up": "^4.1.0",
     "fs-extra": "^8.1.0"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Thinkmill/manypkg.git",
+    "directory": "packages/find-root"
+  },
   "devDependencies": {
     "fixturez": "^1.1.0"
   }

--- a/packages/gatsby-source-workspace/package.json
+++ b/packages/gatsby-source-workspace/package.json
@@ -10,6 +10,11 @@
     "react": "^16.10.1",
     "react-dom": "^16.10.1"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Thinkmill/manypkg.git",
+    "directory": "packages/gatsby-source-workspace"
+  },
   "dependencies": {
     "find-workspaces-root": "^0.2.0",
     "fs-extra": "^8.1.0",

--- a/packages/get-packages/package.json
+++ b/packages/get-packages/package.json
@@ -11,6 +11,11 @@
     "globby": "^11.0.0",
     "read-yaml-file": "^1.1.0"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Thinkmill/manypkg.git",
+    "directory": "packages/get-packages"
+  },
   "devDependencies": {
     "jest-fixtures": "^0.6.0"
   }

--- a/test-gatsby/package.json
+++ b/test-gatsby/package.json
@@ -2,6 +2,11 @@
   "name": "test-gatsby-thing",
   "private": true,
   "version": "0.0.5",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Thinkmill/manypkg.git",
+    "directory": "test-gatsby"
+  },
   "dependencies": {
     "@manypkg/gatsby-source-workspace": "0.4.1",
     "@mdx-js/mdx": "^1.5.1",


### PR DESCRIPTION
Hi there!
This change adds the repository property to your package.json file(s). Having this available provides a number of benefits to security tooling. For example, it allows for greater trust by checking for signed commits, contributors to a release and validating history with the project. It also allows for comparison between the source code and the published artifact in order to detect attacks on authors during the publication process.
We validate that we're making a PR against the correct repository by comparing the metadata for the published artifact on [npmjs.com](www.npmjs.com) against the metadata in the package.json file in the repository.
This change is provided by a team at Microsoft -- we're happy to answer any questions you may have. (Members of this team include [@s-tuli](https://github.com/s-tuli), [@iarna](https://github.com/iarna), [@v-rr](https://github.com/v-rr), [@v-jiepeng](https://github.com/v-jiepeng), [@v-zhzhou](https://github.com/v-zhzhou) and [@v-gjy](https://github.com/v-gjy)). If you would prefer that we not make these sorts of PRs to projects you maintain, please just say. If you'd like to learn more about what we're doing here, we've prepared a document talking about both this project and some of our other activities around supply chain security here: [microsoft/Secure-Supply-Chain](https://github.com/microsoft/Secure-Supply-Chain)
This PR provides repository metadata for the following packages:
* @manypkg/find-root
* @manypkg/gatsby-source-workspace
* @manypkg/get-packages
* test-gatsby-thing