### PR TITLE
fix(pnpm): absolute cwd path matched workspace exclude rules (#121)

### DIFF
--- a/.changeset/fair-days-rest.md
+++ b/.changeset/fair-days-rest.md
@@ -3,4 +3,4 @@
 "@manypkg/get-packages": patch
 ---
 
-fix absolute cwd path matched pnpm worksapce exclude rules
+Fixed getting correct packages in pnpm workspaces with exclude rules.

--- a/.changeset/fair-days-rest.md
+++ b/.changeset/fair-days-rest.md
@@ -1,0 +1,6 @@
+---
+"@manypkg/cli": patch
+"@manypkg/get-packages": patch
+---
+
+fix absolute cwd path matched pnpm worksapce exclude rules

--- a/__fixtures__/pnpm-exclude-workspace-case/package.json
+++ b/__fixtures__/pnpm-exclude-workspace-case/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "name": "pnpm-exclude-workspace-case",
+  "description": "pnpm exclude rule workspace work",
+  "version": "1.0.0"
+}

--- a/__fixtures__/pnpm-exclude-workspace-case/packages/pkg-a/package.json
+++ b/__fixtures__/pnpm-exclude-workspace-case/packages/pkg-a/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "pnpm-exclude-workspace-case-pkg-a",
+  "version": "1.0.0",
+  "dependencies": {
+    "pnpm-exclude-workspace-case-pkg-b": "1.0.0"
+  }
+}

--- a/__fixtures__/pnpm-exclude-workspace-case/packages/pkg-b/package.json
+++ b/__fixtures__/pnpm-exclude-workspace-case/packages/pkg-b/package.json
@@ -1,0 +1,5 @@
+  
+{
+  "name": "pnpm-exclude-workspace-case-pkg-b",
+  "version": "1.0.0"
+}

--- a/__fixtures__/pnpm-exclude-workspace-case/packages/pnpm-exclude-workspace-case/package.json
+++ b/__fixtures__/pnpm-exclude-workspace-case/packages/pnpm-exclude-workspace-case/package.json
@@ -1,0 +1,5 @@
+  
+{
+  "name": "pnpm-exclude-workspace-case-excluded-pkg",
+  "version": "1.0.0"
+}

--- a/__fixtures__/pnpm-exclude-workspace-case/pnpm-workspace.yaml
+++ b/__fixtures__/pnpm-exclude-workspace-case/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+packages:
+  - 'packages/**'
+  # exclude packages that are inside myself name directories
+  - '!**/pnpm-exclude-workspace-case/**'
+  

--- a/packages/get-packages/src/index.test.ts
+++ b/packages/get-packages/src/index.test.ts
@@ -69,6 +69,20 @@ let runTests = (getPackages: GetPackages) => {
     expect(allPackages.tool).toEqual("pnpm");
   });
 
+  it("should resolve workspace for pnpm with exclude rules", async () => {
+    const allPackages = await getPackages(f.copy("pnpm-exclude-workspace-case"));
+    console.log('allPackages: ', allPackages);
+
+    expect(allPackages.packages[0].packageJson.name).toEqual(
+      "pnpm-exclude-workspace-case-pkg-a"
+    );
+    expect(allPackages.packages[1].packageJson.name).toEqual(
+      "pnpm-exclude-workspace-case-pkg-b"
+    );
+    expect(allPackages.packages.length).toEqual(2);
+    expect(allPackages.tool).toEqual("pnpm");
+  })
+
   it("should resolve workspaces for lerna", async () => {
     const allPackages = await getPackages(f.copy("lerna-workspace-base"));
 

--- a/packages/get-packages/src/index.test.ts
+++ b/packages/get-packages/src/index.test.ts
@@ -71,7 +71,6 @@ let runTests = (getPackages: GetPackages) => {
 
   it("should resolve workspace for pnpm with exclude rules", async () => {
     const allPackages = await getPackages(f.copy("pnpm-exclude-workspace-case"));
-    console.log('allPackages: ', allPackages);
 
     expect(allPackages.packages[0].packageJson.name).toEqual(
       "pnpm-exclude-workspace-case-pkg-a"

--- a/packages/get-packages/src/index.ts
+++ b/packages/get-packages/src/index.ts
@@ -110,13 +110,13 @@ export async function getPackages(dir: string): Promise<Packages> {
     };
   }
 
-  const directories = await globby(tool.packageGlobs, {
+  const relativeDirectories = await globby(tool.packageGlobs, {
     cwd,
     onlyDirectories: true,
-    absolute: true,
     expandDirectories: false,
     ignore: ["**/node_modules"]
   });
+  const directories = relativeDirectories.map(p => path.resolve(cwd, p))
 
   let pkgJsonsMissingNameField: Array<string> = [];
 
@@ -234,13 +234,13 @@ export function getPackagesSync(dir: string): Packages {
       packages: [root]
     };
   }
-  const directories = globbySync(tool.packageGlobs, {
+  const relativeDirectories = globbySync(tool.packageGlobs, {
     cwd,
     onlyDirectories: true,
-    absolute: true,
     expandDirectories: false,
     ignore: ["**/node_modules"]
   });
+  const directories = relativeDirectories.map(p => path.resolve(cwd, p))
 
   let pkgJsonsMissingNameField: Array<string> = [];
 


### PR DESCRIPTION
fix #121 