### PR TITLE
install commander, update cli to run using it

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -16,6 +16,7 @@
     "@babel/runtime": "^7.5.5",
     "@manypkg/get-packages": "^1.1.3",
     "chalk": "^2.4.2",
+    "commander": "^8.3.0", 
     "detect-indent": "^6.0.0",
     "find-up": "^4.1.0",
     "fs-extra": "^8.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4046,6 +4046,11 @@ commander@^2.19.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
   integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
 
+commander@^8.3.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
+  integrity sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
+
 common-tags@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.8.0.tgz#8e3153e542d4a39e9b10554434afaaf98956a937"


### PR DESCRIPTION
The help descriptions could probably use a little tweaking, but this mirrors what the cli was doing before while adding a `help` flag using a robust library (commander) that could do even more to improve the dev experience.