### PR TITLE
fix: remove unused get-workspaces from @manypkg/cli

### DIFF
--- a/.changeset/olive-frogs-fly.md
+++ b/.changeset/olive-frogs-fly.md
@@ -2,4 +2,4 @@
 "@manypkg/cli": patch
 ---
 
-fix: remove unused get-workspaces from @manypkg/cli
+Remove unused `get-workspaces` dependency

--- a/.changeset/olive-frogs-fly.md
+++ b/.changeset/olive-frogs-fly.md
@@ -1,0 +1,5 @@
+---
+"@manypkg/cli": patch
+---
+
+fix: remove unused get-workspaces from @manypkg/cli

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -19,7 +19,6 @@
     "detect-indent": "^6.0.0",
     "find-up": "^4.1.0",
     "fs-extra": "^8.1.0",
-    "get-workspaces": "^0.6.0",
     "normalize-path": "^3.0.0",
     "p-limit": "^2.2.1",
     "package-json": "^6.5.0",


### PR DESCRIPTION
- `@manypkg/cli` > `get-workspaces@^0.6.0` > `globby@^9.2.0` has [high severity vulnerability](https://github.com/advisories/GHSA-ww39-953v-wcq6).
- `@manypkg/cli` doesn't use `get-workspaces` since [v0.12.0](https://github.com/Thinkmill/manypkg/blob/master/packages/cli/CHANGELOG.md#0120), #51.
- Related issue: #105