### PR TITLE
Update get-package to @manypkg/get-packages and package-json

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -19,7 +19,7 @@
     "detect-indent": "^6.0.0",
     "find-up": "^4.1.0",
     "fs-extra": "^8.1.0",
-    "get-workspaces": "^0.6.0",
+    "@manypkg/get-packages": "^1.1.3",
     "normalize-path": "^3.0.0",
     "p-limit": "^2.2.1",
     "package-json": "^6.5.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,7 +22,7 @@
     "@manypkg/get-packages": "^1.1.3",
     "normalize-path": "^3.0.0",
     "p-limit": "^2.2.1",
-    "package-json": "^6.5.0",
+    "package-json": "^8.1.0",
     "parse-github-url": "^1.0.2",
     "sembear": "^0.5.0",
     "semver": "^6.3.0",


### PR DESCRIPTION
The `get-package` library is not maintained anymore see here: https://github.com/changesets/changesets/blob/main/packages/get-workspaces/src/index.ts 
There are some libraries connected to the `get-package` library that are vulnerable.

The same is for the library `package-json`, it has a vulnerable version of the library `got` so it needs to be updated too.

If you could please update the library as I suggested