### PR TITLE
Suggested fixes to tsconfig, prettier config

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -8,8 +8,7 @@ module.exports = {
   // Avoid line breaks in markdown
   proseWrap: "never",
 
-  // Disabling search dirs and pointing directly at plugins
-  // makes it easier for VSCode and WebStorm to find them.
+  // Disabling search dirs and pointing directly at plugins to keep configuration explicit
   pluginSearchDirs: false,
   plugins: [require("prettier-plugin-packagejson")],
 };

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,15 @@
+// Documentation for this file: https://prettier.io/docs/en/configuration.html
+module.exports = {
+  // Use .gitattributes to manage newlines
+  endOfLine: "auto",
+
+  // Avoid line breaks in markdown
+  proseWrap: "never",
+
+  // Prettier plugins
+  //
+  // Disabling search dirs and pointing directly at folder paths relative to this config file
+  // makes it easier for VSCode and WebStorm to find your plugins.
+  pluginSearchDirs: [],
+  plugins: ["./node_modules/prettier-plugin-packagejson"]
+};

--- a/package.json
+++ b/package.json
@@ -7,6 +7,18 @@
     "packages/*",
     "test-gatsby"
   ],
+  "scripts": {
+    "postinstall": "preconstruct dev && manypkg check",
+    "release": "yarn preconstruct build && yarn changeset publish",
+    "test": "jest",
+    "test-gatsby": "cd test-gatsby && gatsby develop"
+  },
+  "jest": {
+    "watchPlugins": [
+      "jest-watch-typeahead/filename",
+      "jest-watch-typeahead/testname"
+    ]
+  },
   "dependencies": {
     "@babel/core": "^7.20.5",
     "@babel/preset-env": "^7.20.2",
@@ -22,26 +34,12 @@
     "jest-watch-typeahead": "^0.6.0",
     "preconstruct": "^0.0.89",
     "prettier": "^2.8.1",
+    "prettier-plugin-packagejson": "^2.3.0",
     "typescript": "^4.9.4"
-  },
-  "jest": {
-    "watchPlugins": [
-      "jest-watch-typeahead/filename",
-      "jest-watch-typeahead/testname"
-    ]
   },
   "preconstruct": {
     "packages": [
       "packages/!(gatsby)*"
     ]
-  },
-  "prettier": {
-    "proseWrap": "never"
-  },
-  "scripts": {
-    "postinstall": "preconstruct dev && manypkg check",
-    "release": "yarn preconstruct build && yarn changeset publish",
-    "test-gatsby": "cd test-gatsby && gatsby develop",
-    "test": "jest"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@manypkg/cli",
+  "version": "0.19.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/Thinkmill/manypkg.git",
     "directory": "packages/cli"
   },
-  "version": "0.19.2",
+  "license": "MIT",
   "main": "dist/cli.cjs.js",
   "module": "dist/cli.esm.js",
-  "license": "MIT",
   "bin": {
     "manypkg": "./bin.js"
   },

--- a/packages/find-root/package.json
+++ b/packages/find-root/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@manypkg/find-root",
   "version": "1.1.0",
+  "license": "MIT",
   "main": "dist/find-root.cjs.js",
   "module": "dist/find-root.esm.js",
-  "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.20.6",
     "@types/node": "^12.7.1",

--- a/packages/gatsby-source-workspace/README.md
+++ b/packages/gatsby-source-workspace/README.md
@@ -8,7 +8,7 @@
 // gatsby-config.js
 
 module.exports = {
-  plugins: [{ resolve: "@manypkg/gatsby-source-workspace" }]
+  plugins: [{ resolve: "@manypkg/gatsby-source-workspace" }],
 };
 ```
 
@@ -42,10 +42,10 @@ module.exports = {
     {
       resolve: "@manypkg/gatsby-source-workspace",
       options: {
-        workspaceFilter: workspace => !workspace.packageJSON.private
-      }
-    }
-  ]
+        workspaceFilter: (workspace) => !workspace.packageJSON.private,
+      },
+    },
+  ],
 };
 ```
 
@@ -71,12 +71,12 @@ module.exports = {
         extraFields: [
           {
             name: "license",
-            definition: `String`
-          }
-        ]
-      }
-    }
-  ]
+            definition: `String`,
+          },
+        ],
+      },
+    },
+  ],
 };
 ```
 
@@ -113,13 +113,13 @@ module.exports = {
           {
             name: "readme",
             definition: `String`,
-            getFieldInfo: async ws =>
-              await fs.readFile(path.join(ws.dir, "README.md"), "utf-8")
-          }
-        ]
-      }
-    }
-  ]
+            getFieldInfo: async (ws) =>
+              await fs.readFile(path.join(ws.dir, "README.md"), "utf-8"),
+          },
+        ],
+      },
+    },
+  ],
 };
 ```
 

--- a/packages/gatsby-source-workspace/package.json
+++ b/packages/gatsby-source-workspace/package.json
@@ -2,21 +2,21 @@
   "name": "@manypkg/gatsby-source-workspace",
   "version": "0.4.1",
   "license": "MIT",
-  "peerDependencies": {
-    "gatsby": "^2.15.28"
+  "files": [
+    "gatsby-node.js",
+    "index.js"
+  ],
+  "dependencies": {
+    "find-workspaces-root": "^0.2.0",
+    "fs-extra": "^8.1.0",
+    "get-workspaces": "^0.6.0"
   },
   "devDependencies": {
     "gatsby": "^2.15.28",
     "react": "^16.10.1",
     "react-dom": "^16.10.1"
   },
-  "dependencies": {
-    "find-workspaces-root": "^0.2.0",
-    "fs-extra": "^8.1.0",
-    "get-workspaces": "^0.6.0"
-  },
-  "files": [
-    "gatsby-node.js",
-    "index.js"
-  ]
+  "peerDependencies": {
+    "gatsby": "^2.15.28"
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -46,9 +46,10 @@
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
     // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
+    "useUnknownInCatchVariables": false
 
     /* Source Map Options */
     // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -49,7 +49,6 @@
     "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
     // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
-    "useUnknownInCatchVariables": false
 
     /* Source Map Options */
     // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -5747,7 +5747,7 @@ detect-libc@^1.0.2:
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
   integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
-detect-newline@^3.0.0:
+detect-newline@3.1.0, detect-newline@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
@@ -7607,6 +7607,11 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
+git-hooks-list@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/git-hooks-list/-/git-hooks-list-1.0.3.tgz#be5baaf78203ce342f2f844a9d2b03dba1b45156"
+  integrity sha512-Y7wLWcrLUXwk2noSka166byGCvhMtDRpgHdzCno1UQv/n/Hegp++a2xBWJL1lJarnKD3SWaljD+0z1ztqxuKyQ==
+
 git-up@4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/git-up/-/git-up-4.0.1.tgz#cb2ef086653640e721d2042fe3104857d89007c0"
@@ -7693,6 +7698,20 @@ globals@^11.1.0, globals@^11.7.0:
   version "11.12.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
+
+globby@10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-10.0.0.tgz#abfcd0630037ae174a88590132c2f6804e291072"
+  integrity sha512-3LifW9M4joGZasyYPz2A1U74zbC/45fvpXUvO/9KbSa+VV0aGZarWkfdgKyR9sExNP0t0x0ss/UMJpNpcaTspw==
+  dependencies:
+    "@types/glob" "^7.1.1"
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.0.3"
+    glob "^7.1.3"
+    ignore "^5.1.1"
+    merge2 "^1.2.3"
+    slash "^3.0.0"
 
 globby@^10.0.1:
   version "10.0.1"
@@ -9030,6 +9049,11 @@ is-path-inside@^3.0.1:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.2.tgz#f5220fc82a3e233757291dddc9c5877f2a1f3017"
   integrity sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==
+
+is-plain-obj@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz#45e42e37fccf1f40da8e5f76ee21515840c09287"
+  integrity sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
 
 is-plain-obj@^1.0.0, is-plain-obj@^1.1.0:
   version "1.1.0"
@@ -12361,6 +12385,13 @@ prepend-http@^2.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
 
+prettier-plugin-packagejson@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-packagejson/-/prettier-plugin-packagejson-2.3.0.tgz#5c242a39627c227d813161618fa88e64e44e9c84"
+  integrity sha512-2SAPMMk1UDkqsB7DifWKcwCm6VC52JXMrzLHfbcQHJRWhRCj9zziOy+s+2XOyPBeyqFqS+A/1IKzOrxKFTo6pw==
+  dependencies:
+    sort-package-json "1.57.0"
+
 prettier@^1.18.2:
   version "1.18.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
@@ -14040,6 +14071,23 @@ sort-keys@^2.0.0:
   integrity sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=
   dependencies:
     is-plain-obj "^1.0.0"
+
+sort-object-keys@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/sort-object-keys/-/sort-object-keys-1.1.3.tgz#bff833fe85cab147b34742e45863453c1e190b45"
+  integrity sha512-855pvK+VkU7PaKYPc+Jjnmt4EzejQHyhhF33q31qG8x7maDzkeFhAAThdCYay11CISO+qAMwjOBP+fPZe0IPyg==
+
+sort-package-json@1.57.0:
+  version "1.57.0"
+  resolved "https://registry.yarnpkg.com/sort-package-json/-/sort-package-json-1.57.0.tgz#e95fb44af8ede0bb6147e3f39258102d4bb23fc4"
+  integrity sha512-FYsjYn2dHTRb41wqnv+uEqCUvBpK3jZcTp9rbz2qDTmel7Pmdtf+i2rLaaPMRZeSVM60V3Se31GyWFpmKs4Q5Q==
+  dependencies:
+    detect-indent "^6.0.0"
+    detect-newline "3.1.0"
+    git-hooks-list "1.0.3"
+    globby "10.0.0"
+    is-plain-obj "2.1.0"
+    sort-object-keys "^1.1.3"
 
 source-list-map@^1.1.1:
   version "1.1.2"


### PR DESCRIPTION
### SUMMARY

 - Move _prettier config_ into Prettier's dedicated config file, for ease of discovery
 - Add the `prettier-plugin-packagejson` prettier plugin
 - Turn off `useUnknownInCatchVariables` typescript rule

### DETAILS

I am open to pushback on this, but I think in general, using `package.json` as an unstructured grab-bag is less discoverable than using tool-specific configuration files. So I was hoping to split out `.prettierrc.js` into its own file in the root.

It would also be nice to add `prettier-plugin-packagejson` -- it's very opinionated, as it wraps the opinionated `sort-package-json` utility, but I've found it really nice to just give in and let VSCode auto-sort my whole packagejson every time I touch it.

Last, I think we (and everyone else) should turn off `useUnknownInCatchVariables`. Notably, even the [TypeScript codebase itself turns this off](https://github.com/microsoft/TypeScript/issues/42596) -- the extra safety is not worth the hassle until TS starts offering some better assumptions (like at least being able to specify `err: Error`).