### PR TITLE
Add missing MIT LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Thinkmill Labs Pty Ltd
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
This project is relying only on the SPDX identifier for determining the governing LICENSE.
For the avoidance of doubt, the project should have a `LICENSE` file and reference in the `README`.

Contacting every collaborator to acknowledge
- [ ] @emmatown 
- [ ] @Andarist 
- [ ] @Noviny 
- [ ] @elliot-nelson 
- [ ] @tarang9211
- [ ] @maraisr
- [ ] @jesstelford
- [ ] @NateRadebaugh
- [ ] @jakeboone02
- [ ] @chalkpe
- [ ] @fz6m
- [ ] @marcodejongh
- [ ] @jroebu14
- [ ] @acao
- [ ] @with-heart
- [ ] @SalimBensiali
- [ ] @zzarcon
- [ ] @evocateur
- [ ] @clentfort