### PR TITLE
enable possibility to end name with "/" for scoped packages

### DIFF
--- a/packages/cli/src/upgrade.ts
+++ b/packages/cli/src/upgrade.ts
@@ -11,7 +11,7 @@ export async function upgradeDependency([name, tag = "latest"]: string[]) {
   let { packages, tool, rootPackage, rootDir } = await getPackages(
     process.cwd()
   );
-  let isScope = name.startsWith("@") && !name.includes("/");
+  let isScope = name.startsWith("@") && (!name.includes("/") || name.endsWith("/"));
   let newVersion = semver.validRange(tag) ? tag : null;
 
   let packagesToUpdate = new Set<string>();


### PR DESCRIPTION
This would be very helpful to still upgrade scoped packages like `@scoped-name/` which currently fails:
```
manypkg upgrade @scoped-name/
```