### PR TITLE
Bump package-json in CLI package.json from 6.5.0 to 8.1.0 (Vul Fix)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,7 +20,7 @@
     "fs-extra": "^8.1.0",
     "normalize-path": "^3.0.0",
     "p-limit": "^2.2.1",
-    "package-json": "^6.5.0",
+    "package-json": "^8.1.0",
     "parse-github-url": "^1.0.2",
     "sembear": "^0.5.0",
     "semver": "^6.3.0",


### PR DESCRIPTION
package-json 6.5.0 used was on an older version of the dependency called 'got' which has this issue "Got allows a redirect to a UNIX socket -  https://github.com/advisories/GHSA-pfrx-2q88-qq97"