### PR TITLE
Update and move `@types/node` to dev updates

### DIFF
--- a/.changeset/node-types-lag.md
+++ b/.changeset/node-types-lag.md
@@ -1,0 +1,5 @@
+---
+"@manypkg/find-root": patch
+---
+
+Remove `@types/node` dependency

--- a/.changeset/node-types-lag.md
+++ b/.changeset/node-types-lag.md
@@ -2,4 +2,4 @@
 "@manypkg/find-root": patch
 ---
 
-Remove `@types/node` dependency
+Moved `@types/node` out of `dependencies` to `devDependencies`

--- a/packages/find-root/package.json
+++ b/packages/find-root/package.json
@@ -6,11 +6,11 @@
   "module": "dist/manypkg-find-root.esm.js",
   "dependencies": {
     "@manypkg/tools": "^1.1.0",
-    "@types/node": "^12.7.1",
     "find-up": "^4.1.0",
     "fs-extra": "^8.1.0"
   },
   "devDependencies": {
+    "@types/node": "^16.11.7",
     "fixturez": "^1.1.0"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2088,7 +2088,12 @@
   resolved "https://registry.yarnpkg.com/@types/mkdirp/-/mkdirp-0.3.29.tgz#7f2ad7ec55f914482fc9b1ec4bb1ae6028d46066"
   integrity sha1-fyrX7FX5FEgvybHsS7GuYCjUYGY=
 
-"@types/node@*", "@types/node@^12.7.1":
+"@types/node@*", "@types/node@^16.11.7":
+  version "16.18.37"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.37.tgz#a1f8728e4dc30163deb41e9b7aba65d0c2d4eda1"
+  integrity sha512-ql+4dw4PlPFBP495k8JzUX/oMNRI2Ei4PrMHgj8oT4VhGlYUzF4EYr0qk2fW+XBVGIrq8Zzk13m4cvyXZuv4pA==
+
+"@types/node@^12.7.1":
   version "12.7.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.1.tgz#3b5c3a26393c19b400844ac422bd0f631a94d69d"
   integrity sha512-aK9jxMypeSrhiYofWWBf/T7O+KwaiAHzM4sveCdWPn71lzUSMimRnKzhXDKfKwV1kWoBo2P1aGgaIYGLf9/ljw==


### PR DESCRIPTION
`@types/node` should not be a dependency for `find-root` since it doesn't expose any of the node types in its API, so I've moved it to a dev dep. I also updated the version to the last Node 16 types version. I chose Node 16 as it's [the same version used in CI](https://github.com/Thinkmill/manypkg/blob/main/.github/workflows/main.yml#L19).

Fixes #118.