### PR TITLE
Start support for `workspace:` protocol for internal packages

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,5 +6,6 @@
   ],
   "commit": false,
   "linked": [],
-  "access": "public"
+  "access": "public",
+  "baseBranch": "main"
 }

--- a/.changeset/yellow-pans-sort.md
+++ b/.changeset/yellow-pans-sort.md
@@ -1,0 +1,5 @@
+---
+"@manypkg/cli": minor
+---
+
+Start support for `workspace:` protocol for internal packages


### PR DESCRIPTION
This PR starts support for the `workspace:` protocol and does many of the things as discussed in #72 to make this tool usable with pnpm.

I think the code is pretty self-explanatory, also added a bunch of test for coverage.

Explicitly opts out of trying to fix errors, because I'm not sure whether that's 1) safe to do and/or 2) desired in all cases. I know in my own test workloads it's not what I want.

An option could be added to prefer the `workspace:` protocol but that's also outside the scope of this PR.