### PR TITLE
chore: more tests for pnpm workspace definitions

### DIFF
--- a/__fixtures__/pnpm-workspace-base/more-packages/pkg-g/package.json
+++ b/__fixtures__/pnpm-workspace-base/more-packages/pkg-g/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "pnpm-workspace-base-pkg-g",
+  "version": "1.0.0"
+}

--- a/__fixtures__/pnpm-workspace-base/more-packages/pkg-h/package.json
+++ b/__fixtures__/pnpm-workspace-base/more-packages/pkg-h/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "pnpm-workspace-base-pkg-h",
+  "version": "1.0.0"
+}

--- a/__fixtures__/pnpm-workspace-base/other-packages/pkg-c/package.json
+++ b/__fixtures__/pnpm-workspace-base/other-packages/pkg-c/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "pnpm-workspace-base-pkg-c",
+  "version": "1.0.0",
+  "dependencies": {
+    "pnpm-workspace-base-pkg-d": "1.0.0"
+  }
+}

--- a/__fixtures__/pnpm-workspace-base/other-packages/pkg-d/package.json
+++ b/__fixtures__/pnpm-workspace-base/other-packages/pkg-d/package.json
@@ -1,0 +1,5 @@
+
+{
+  "name": "pnpm-workspace-base-pkg-d",
+  "version": "1.0.0"
+}

--- a/__fixtures__/pnpm-workspace-base/other-packages/subfolder/pkg-x/package.json
+++ b/__fixtures__/pnpm-workspace-base/other-packages/subfolder/pkg-x/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "pnpm-workspace-base-pkg-x",
+  "version": "1.0.0"
+}

--- a/__fixtures__/pnpm-workspace-base/packages/subfolder/pkg-b/package.json
+++ b/__fixtures__/pnpm-workspace-base/packages/subfolder/pkg-b/package.json
@@ -1,4 +1,4 @@
-  
+
 {
   "name": "pnpm-workspace-base-pkg-b",
   "version": "1.0.0"

--- a/__fixtures__/pnpm-workspace-base/pkg-e/package.json
+++ b/__fixtures__/pnpm-workspace-base/pkg-e/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "pnpm-workspace-base-pkg-e",
+  "version": "1.0.0",
+  "private": true
+}

--- a/__fixtures__/pnpm-workspace-base/pkg-f/package.json
+++ b/__fixtures__/pnpm-workspace-base/pkg-f/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "pnpm-workspace-base-pkg-f",
+  "version": "1.0.0"
+}

--- a/__fixtures__/pnpm-workspace-base/pnpm-workspace.yaml
+++ b/__fixtures__/pnpm-workspace-base/pnpm-workspace.yaml
@@ -1,2 +1,7 @@
 packages:
-  - '**'
+  - 'packages/**'
+  - 'other-packages/*'
+  - 'pkg-e/'
+  - 'pkg-f'
+  - 'more-packages/pkg-g'
+  - 'more-packages/pkg-h/'

--- a/packages/get-packages/src/index.test.ts
+++ b/packages/get-packages/src/index.test.ts
@@ -60,11 +60,31 @@ let runTests = (getPackages: GetPackages) => {
       return expect(allPackages.packages).not.toBeNull();
     }
 
+    expect(allPackages.packages).toHaveLength(8);
+
     expect(allPackages.packages[0].packageJson.name).toEqual(
-      "pnpm-workspace-base-pkg-a"
+      "pnpm-workspace-base-pkg-g"
     );
     expect(allPackages.packages[1].packageJson.name).toEqual(
+      "pnpm-workspace-base-pkg-h"
+    );
+    expect(allPackages.packages[2].packageJson.name).toEqual(
+      "pnpm-workspace-base-pkg-c"
+    );
+    expect(allPackages.packages[3].packageJson.name).toEqual(
+      "pnpm-workspace-base-pkg-d"
+    );
+    expect(allPackages.packages[4].packageJson.name).toEqual(
+      "pnpm-workspace-base-pkg-a"
+    );
+    expect(allPackages.packages[5].packageJson.name).toEqual(
       "pnpm-workspace-base-pkg-b"
+    );
+    expect(allPackages.packages[6].packageJson.name).toEqual(
+      "pnpm-workspace-base-pkg-e"
+    );
+    expect(allPackages.packages[7].packageJson.name).toEqual(
+      "pnpm-workspace-base-pkg-f"
     );
     expect(allPackages.tool.type).toEqual("pnpm");
   });


### PR DESCRIPTION
I was investigating this issue https://github.com/changesets/changesets/issues/1209 and started adding tests here to check if the issue is in manypkg. Turned out changeset is using an older version and `get-packages` is working correctly.

I'm not sure if you want, but might make sense to add these tests anyway.