### PR TITLE
feat: detect package manager for fix cmd

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -16,6 +16,7 @@
     "@manypkg/get-packages": "^2.2.0",
     "chalk": "^2.4.2",
     "detect-indent": "^6.0.0",
+    "detect-package-manager": "^3.0.1",
     "find-up": "^4.1.0",
     "fs-extra": "^8.1.0",
     "normalize-path": "^3.0.0",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,7 @@
 import path from "path";
 import * as logger from "./logger";
 import { getPackages, Packages, Package } from "@manypkg/get-packages";
+import { PM, detect as detectPackageManager } from "detect-package-manager";
 import { Options } from "./checks/utils";
 import { checks } from "./checks";
 import { ExitError } from "./errors";
@@ -146,6 +147,9 @@ async function execCmd(args: string[]) {
     shouldFix,
     options
   );
+  const packageManager: PM = await detectPackageManager({
+    cwd: rootDir,
+  }).catch(() => "yarn");
   if (shouldFix) {
     await Promise.all(
       [...packagesByName].map(async ([pkgName, workspace]) => {
@@ -158,7 +162,9 @@ async function execCmd(args: string[]) {
 
     logger.success(`fixed workspaces!`);
   } else if (hasErrored) {
-    logger.info(`the above errors may be fixable with yarn manypkg fix`);
+    logger.info(
+      `the above errors may be fixable with ${packageManager} manypkg fix`
+    );
     throw new ExitError(1);
   } else {
     logger.success(`workspaces valid!`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4942,6 +4942,13 @@ detect-node@^2.0.4:
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.4.tgz#014ee8f8f669c5c58023da64b8179c083a28c46c"
   integrity sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==
 
+detect-package-manager@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/detect-package-manager/-/detect-package-manager-3.0.1.tgz#ec9689915b47e2ecf3774118849bc7033f0a2151"
+  integrity sha512-qoHDH6+lMcpJPAScE7+5CYj91W0mxZNXTwZPrCqi1KMk+x+AoQScQ2V1QyqTln1rHU5Haq5fikvOGHv+leKD8A==
+  dependencies:
+    execa "^5.1.1"
+
 detect-port-alt@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/detect-port-alt/-/detect-port-alt-1.1.3.tgz#a4d2f061d757a034ecf37c514260a98750f2b131"
@@ -5784,7 +5791,7 @@ execa@^2.0.4:
     signal-exit "^3.0.2"
     strip-final-newline "^2.0.0"
 
-execa@^5.0.0:
+execa@^5.0.0, execa@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/execa/-/execa-5.1.1.tgz#f80ad9cbf4298f7bd1d4c9555c21e93741c411dd"
   integrity sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==


### PR DESCRIPTION
Improve the provided fix command for convenience.

```sh
> manypkg check

☔️ error X dependencies are unsorted, this can cause large diffs when packages are added, resulting in dependencies being sorted
☔️ info the above errors may be fixable with yarn manypkg fix
```