### PR TITLE
Fix Upgrade to Properly Update Scoped Packages

### DIFF
--- a/.changeset/weak-icons-invent.md
+++ b/.changeset/weak-icons-invent.md
@@ -1,0 +1,5 @@
+---
+"@manypkg/cli": patch
+---
+
+Fix `manypkg upgrade @scope` upgrading packages like `@scope-something/a`

--- a/packages/cli/src/upgrade.ts
+++ b/packages/cli/src/upgrade.ts
@@ -24,7 +24,7 @@ export async function upgradeDependency([name, tag = "latest"]: string[]) {
 
       let packageNames = Object.keys(deps);
       packageNames.forEach((pkgName) => {
-        if ((isScope && pkgName.startsWith(name)) || pkgName === name) {
+        if ((isScope && pkgName.startsWith(`${name}/`)) || pkgName === name) {
           requiresUpdate = true;
           packagesToUpdate.add(pkgName);
         }
@@ -42,7 +42,7 @@ export async function upgradeDependency([name, tag = "latest"]: string[]) {
 
       let packageNames = Object.keys(deps);
       packageNames.forEach((pkgName) => {
-        if ((isScope && pkgName.startsWith(name)) || pkgName === name) {
+        if ((isScope && pkgName.startsWith(`${name}/`)) || pkgName === name) {
           rootRequiresUpdate = true;
           packagesToUpdate.add(pkgName);
         }


### PR DESCRIPTION
### Issue
Running `manypkg upgrade @scope` currently upgrades packages formatted as `@scope/package` and `@scope-extra/package`. This is problematic because it should not be updating `@scope-extra/` packages.

### Solution
Properly upgrade package so `manypkg upgrade @scope` only upgrades `@scope/` packages and `manypkg upgrade @scope-extras` only upgrades `@scope-extras/` packages.

### Related
- Addresses #148
- Fixes the PR changes requested in #175