### PR TITLE
remove six yaml-related dependencies

### DIFF
--- a/.changeset/curvy-garlics-exercise.md
+++ b/.changeset/curvy-garlics-exercise.md
@@ -1,0 +1,5 @@
+---
+"@manypkg/tools": patch
+---
+
+Replace `read-yaml-file` with `js-yaml`

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -12,10 +12,11 @@
     "fs-extra": "^8.1.0",
     "globby": "^11.0.0",
     "jju": "^1.4.0",
-    "read-yaml-file": "^1.1.0"
+    "js-yaml": "^4.1.0"
   },
   "devDependencies": {
     "@types/jju": "^1.4.2",
+    "@types/js-yaml": "^4.0.9",
     "jest-fixtures": "^0.6.0"
   },
   "engines": {

--- a/packages/tools/src/PnpmTool.ts
+++ b/packages/tools/src/PnpmTool.ts
@@ -13,18 +13,11 @@ import {
   expandPackageGlobsSync,
 } from "./expandPackageGlobs";
 
-function stripBom(s: string) {
-	// Catches EFBBBF (UTF-8 BOM) because the buffer-to-string
-	// conversion translates it to FEFF (UTF-16 BOM).
-	return s.charCodeAt(0) === 0xFEFF ? s.slice(1) : s;
+async function readYamlFile<T = unknown>(path: string): Promise<T> {
+  return fs.promises.readFile(path, 'utf8').then(data => yaml.load(data)) as Promise<T>;
 }
-
-const parse = (data: string) => yaml.load(stripBom(data))
-async function readYamlFile<T = unknown>(path: string) {
-  return fs.promises.readFile(path, 'utf8').then(data => parse(data));
-}
-function readYamlFileSync<T = unknown>(path: string) {
-  return parse(fs.readFileSync(path, 'utf8'));
+function readYamlFileSync<T = unknown>(path: string): T {
+  return yaml.load(fs.readFileSync(path, 'utf8')) as T;
 }
 
 export interface PnpmWorkspaceYaml {

--- a/packages/tools/src/PnpmTool.ts
+++ b/packages/tools/src/PnpmTool.ts
@@ -1,10 +1,9 @@
 import path from "path";
-import readYamlFile, { sync as readYamlFileSync } from "read-yaml-file";
+import yaml from "js-yaml";
 import fs from "fs-extra";
 
 import {
   Tool,
-  Package,
   PackageJSON,
   Packages,
   InvalidMonorepoError,
@@ -13,6 +12,20 @@ import {
   expandPackageGlobs,
   expandPackageGlobsSync,
 } from "./expandPackageGlobs";
+
+function stripBom(s: string) {
+	// Catches EFBBBF (UTF-8 BOM) because the buffer-to-string
+	// conversion translates it to FEFF (UTF-16 BOM).
+	return s.charCodeAt(0) === 0xFEFF ? s.slice(1) : s;
+}
+
+const parse = (data: string) => yaml.load(stripBom(data))
+async function readYamlFile<T = unknown>(path: string) {
+  return fs.promises.readFile(path, 'utf8').then(data => parse(data));
+}
+function readYamlFileSync<T = unknown>(path: string) {
+  return parse(fs.readFileSync(path, 'utf8'));
+}
 
 export interface PnpmWorkspaceYaml {
   packages?: string[];

--- a/yarn.lock
+++ b/yarn.lock
@@ -2094,6 +2094,11 @@
   resolved "https://registry.yarnpkg.com/@types/jju/-/jju-1.4.2.tgz#cb31d10d9e23a1b2786a9842c584b53f6f1b9086"
   integrity sha512-fbvsM6TrP3QN6791tiF6wAkmlNRwf1VARZ7sXyc5kmbfTDFhECaiS5ZFvpaciud0BoKBBFWA8hE3utOLf5XB1w==
 
+"@types/js-yaml@^4.0.9":
+  version "4.0.9"
+  resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-4.0.9.tgz#cd82382c4f902fed9691a2ed79ec68c5898af4c2"
+  integrity sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==
+
 "@types/json-schema@^7.0.3":
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.3.tgz#bdfd69d61e464dcc81b25159c270d75a73c1a636"
@@ -2656,6 +2661,11 @@ argparse@^1.0.7:
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   dependencies:
     sprintf-js "~1.0.2"
+
+argparse@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
 aria-query@^3.0.0:
   version "3.0.0"
@@ -9157,6 +9167,13 @@ js-yaml@^3.10.0, js-yaml@^3.11.0, js-yaml@^3.13.0, js-yaml@^3.13.1, js-yaml@^3.5
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
+
+js-yaml@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
+  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+  dependencies:
+    argparse "^2.0.1"
 
 jsesc@^2.5.1:
   version "2.5.2"


### PR DESCRIPTION
Replaces https://npmgraph.js.org/?q=read-yaml-file@1.1.0 with https://npmgraph.js.org/?q=js-yaml

`read-yaml-file` barely does anything and is just tiny wrapper around `js-yaml` that calls `strip-bom`. However, `strip-bom` is unnecessary as `js-yaml` now strips the bom character by itself: https://github.com/nodeca/js-yaml/blob/0d3ca7a27b03a6c974790a30a89e456007d62976/lib/loader.js#L1665