### PR TITLE
remove find-up to remove six dependencies

### DIFF
--- a/.changeset/cool-goats-kiss.md
+++ b/.changeset/cool-goats-kiss.md
@@ -1,0 +1,5 @@
+---
+"@manypkg/find-root": patch
+---
+
+Remove find-up dependency

--- a/packages/find-root/package.json
+++ b/packages/find-root/package.json
@@ -11,7 +11,6 @@
   "module": "dist/manypkg-find-root.esm.js",
   "dependencies": {
     "@manypkg/tools": "^1.1.1",
-    "find-up": "^4.1.0",
     "fs-extra": "^8.1.0"
   },
   "devDependencies": {

--- a/packages/find-root/src/index.ts
+++ b/packages/find-root/src/index.ts
@@ -1,6 +1,5 @@
 import path from "path";
 import fs from "fs-extra";
-import fsp from "fs/promises";
 
 import {
   Tool,
@@ -190,7 +189,7 @@ export function findRootSync(
   };
 }
 
-export async function findUp(matcher: (directory: string) => Promise<string | undefined>, cwd = process.cwd()) {
+async function findUp(matcher: (directory: string) => Promise<string | undefined>, cwd: string) {
 	let directory = path.resolve(cwd);
 	const { root } = path.parse(directory);
 
@@ -204,7 +203,7 @@ export async function findUp(matcher: (directory: string) => Promise<string | un
 	}
 }
 
-export function findUpSync(matcher: (directory: string) => string | undefined, cwd = process.cwd()) {
+function findUpSync(matcher: (directory: string) => string | undefined, cwd: string) {
 	let directory = path.resolve(cwd);
 	const { root } = path.parse(directory);
 

--- a/packages/find-root/src/index.ts
+++ b/packages/find-root/src/index.ts
@@ -1,6 +1,6 @@
-import findUp, { sync as findUpSync } from "find-up";
 import path from "path";
 import fs from "fs-extra";
+import fsp from "fs/promises";
 
 import {
   Tool,
@@ -98,7 +98,7 @@ export async function findRoot(
           }
         });
     },
-    { cwd, type: "directory" }
+    cwd
   );
 
   if (monorepoRoot) {
@@ -123,7 +123,7 @@ export async function findRoot(
         }
       }
     },
-    { cwd, type: "directory" }
+    cwd
   );
 
   if (!rootDir) {
@@ -158,7 +158,7 @@ export function findRootSync(
         }
       }
     },
-    { cwd, type: "directory" }
+    cwd
   );
 
   if (monorepoRoot) {
@@ -177,7 +177,7 @@ export function findRootSync(
       const exists = fs.existsSync(path.join(directory, "package.json"));
       return exists ? directory : undefined;
     },
-    { cwd, type: "directory" }
+    cwd
   );
 
   if (!rootDir) {
@@ -188,4 +188,32 @@ export function findRootSync(
     tool: RootTool,
     rootDir,
   };
+}
+
+export async function findUp(matcher: (directory: string) => Promise<string | undefined>, cwd = process.cwd()) {
+	let directory = path.resolve(cwd);
+	const { root } = path.parse(directory);
+
+	while (directory && directory !== root) {
+		const filePath = await matcher(directory);
+		if (filePath) {
+			return path.resolve(directory, filePath);
+		}
+
+		directory = path.dirname(directory);
+	}
+}
+
+export function findUpSync(matcher: (directory: string) => string | undefined, cwd = process.cwd()) {
+	let directory = path.resolve(cwd);
+	const { root } = path.parse(directory);
+
+	while (directory && directory !== root) {
+		const filePath = matcher(directory);
+		if (filePath) {
+			return path.resolve(directory, filePath);
+		}
+
+		directory = path.dirname(directory);
+	}
 }


### PR DESCRIPTION
it's a relatively simple piece of functionality, so probably don't need 6 dependencies for it

https://npmgraph.js.org/?q=find-up@4.1.0