### PR TITLE
[dependencies-replacement] Update validate-npm-package-name to 5.0.1, removing one subdependency

### DIFF
--- a/.changeset/spotty-planets-grin.md
+++ b/.changeset/spotty-planets-grin.md
@@ -1,0 +1,5 @@
+---
+"@manypkg/cli": minor
+---
+
+Update `validate-npm-package-name` to `5.0.1` to remove one transitive dependency.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,7 +25,7 @@
     "sembear": "^0.5.0",
     "semver": "^6.3.0",
     "spawndamnit": "^2.0.0",
-    "validate-npm-package-name": "^3.0.0"
+    "validate-npm-package-name": "^5.0.1"
   },
   "devDependencies": {
     "fixturez": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3495,11 +3495,6 @@ builtin-status-codes@^3.0.0:
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
   integrity sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=
 
-builtins@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/builtins/-/builtins-1.0.3.tgz#cb94faeb61c8696451db36534e1422f94f0aee88"
-  integrity sha1-y5T662HIaWRR2zZTThQi+U8K7og=
-
 bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
@@ -14797,12 +14792,10 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-validate-npm-package-name@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz#5fa912d81eb7d0c74afc140de7317f0ca7df437e"
-  integrity sha1-X6kS2B630MdK/BQN5zF/DKffQ34=
-  dependencies:
-    builtins "^1.0.3"
+validate-npm-package-name@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz#a316573e9b49f3ccd90dbb6eb52b3f06c6d604e8"
+  integrity sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==
 
 vary@^1, vary@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
Removes transitive dependency on `builtins` package. Version `5.0.1` is the last one with node 14 support in its `engines` field, even though `6.0.0` has the exact same source-code :-/

references #221 