### PR TITLE
Revert unnecessary change to babel config

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -4,8 +4,6 @@ module.exports = {
       "@babel/preset-env",
       {
         targets: { node: 14 },
-        // necessary to preserve dynamic import of ESM-only modules
-        exclude: ["proposal-dynamic-import"],
       },
     ],
     "@babel/preset-typescript",


### PR DESCRIPTION
Turns out, @Andarist was correct in https://github.com/Thinkmill/manypkg/pull/231#discussion_r1804429503 - because babel was updated, this setting is not needed. 