### PR TITLE
Add Bun Support to manypkg

### DIFF
--- a/.changeset/ten-moose-clean.md
+++ b/.changeset/ten-moose-clean.md
@@ -1,0 +1,13 @@
+---
+"@manypkg/get-packages": minor
+"@manypkg/find-root": minor
+"@manypkg/tools": minor
+"@manypkg/cli": minor
+---
+
+feat: add bun support
+
+- Add BunTool implementation for detecting and working with bun monorepos
+- Support for bun.lockb and bun.lock files
+- Integrate bun tool detection into the monorepo tool system
+- Update CLI to handle bun package management commands

--- a/.changeset/ten-moose-clean.md
+++ b/.changeset/ten-moose-clean.md
@@ -5,9 +5,4 @@
 "@manypkg/cli": minor
 ---
 
-feat: add bun support
-
-- Add BunTool implementation for detecting and working with bun monorepos
-- Support for bun.lockb and bun.lock files
-- Integrate bun tool detection into the monorepo tool system
-- Update CLI to handle bun package management commands
+Add Bun support

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 # Manypkg
 
-Manypkg is a linter for `package.json` files in Yarn, npm or pnpm monorepos.
+Manypkg is a linter for `package.json` files in Yarn, npm, pnpm, Bun or Lerna monorepos.
 
 ## Install
 

--- a/__fixtures__/basic-bun-json-lock/bun.lock
+++ b/__fixtures__/basic-bun-json-lock/bun.lock
@@ -1,0 +1,4 @@
+{
+  "version": "lockfile/5",
+  "lockfile": {}
+} 

--- a/__fixtures__/basic-bun-json-lock/package.json
+++ b/__fixtures__/basic-bun-json-lock/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "basic-bun-json-lock",
+  "version": "1.0.0",
+  "private": true,
+  "workspaces": [
+    "packages/*"
+  ]
+} 

--- a/__fixtures__/basic-bun-json-lock/packages/package-one/package.json
+++ b/__fixtures__/basic-bun-json-lock/packages/package-one/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "basic-bun-json-lock-package-one",
+  "version": "1.0.0",
+  "main": "src/index.js"
+} 

--- a/__fixtures__/basic-bun-json-lock/packages/package-one/src/index.js
+++ b/__fixtures__/basic-bun-json-lock/packages/package-one/src/index.js
@@ -1,0 +1,1 @@
+module.exports = "package-one"; 

--- a/__fixtures__/basic-bun/bun.lockb
+++ b/__fixtures__/basic-bun/bun.lockb
@@ -1,0 +1,1 @@
+# This is a placeholder bun.lockb file for testing purposes 

--- a/__fixtures__/basic-bun/package.json
+++ b/__fixtures__/basic-bun/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "basic-bun",
+  "version": "1.0.0",
+  "private": true,
+  "workspaces": [
+    "packages/*"
+  ]
+} 

--- a/__fixtures__/basic-bun/packages/package-one/package.json
+++ b/__fixtures__/basic-bun/packages/package-one/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "basic-bun-package-one",
+  "version": "1.0.0",
+  "main": "src/index.js"
+} 

--- a/__fixtures__/basic-bun/packages/package-one/src/index.js
+++ b/__fixtures__/basic-bun/packages/package-one/src/index.js
@@ -1,0 +1,1 @@
+module.exports = "package-one"; 

--- a/__fixtures__/bun-no-lock/package.json
+++ b/__fixtures__/bun-no-lock/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "bun-no-lock",
+  "version": "1.0.0",
+  "private": true,
+  "workspaces": [
+    "packages/*"
+  ]
+} 

--- a/__fixtures__/bun-no-lock/packages/package-one/package.json
+++ b/__fixtures__/bun-no-lock/packages/package-one/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "bun-no-lock-package-one",
+  "version": "1.0.0",
+  "main": "src/index.js"
+} 

--- a/__fixtures__/bun-workspace-base/bun.lockb
+++ b/__fixtures__/bun-workspace-base/bun.lockb
@@ -1,0 +1,1 @@
+# This is a placeholder bun.lockb file for testing purposes 

--- a/__fixtures__/bun-workspace-base/package.json
+++ b/__fixtures__/bun-workspace-base/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "bun-workspace-base",
+  "version": "1.0.0",
+  "private": true,
+  "workspaces": [
+    "packages/*"
+  ]
+} 

--- a/__fixtures__/bun-workspace-base/packages/pkg-a/package.json
+++ b/__fixtures__/bun-workspace-base/packages/pkg-a/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "bun-workspace-base-pkg-a",
+  "version": "1.0.0",
+  "main": "src/index.js"
+} 

--- a/__fixtures__/bun-workspace-base/packages/pkg-b/package.json
+++ b/__fixtures__/bun-workspace-base/packages/pkg-b/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "bun-workspace-base-pkg-b",
+  "version": "1.0.0",
+  "main": "src/index.js"
+} 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,6 +1,6 @@
 # Manypkg
 
-Manypkg is a linter for `package.json` files in Yarn, npm, Lerna, pnpm or Rush monorepos.
+Manypkg is a linter for `package.json` files in Yarn, npm, Lerna, pnpm, Bun or Rush monorepos.
 
 ## Install
 

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -16,6 +16,7 @@ export async function writePackage(pkg: Package) {
 
 export async function install(toolType: string, cwd: string) {
   const cliRunners: Record<string, string> = {
+    bun: "bun",
     lerna: "lerna",
     npm: "npm",
     pnpm: "pnpm",
@@ -26,7 +27,7 @@ export async function install(toolType: string, cwd: string) {
 
   await exec(
     cliRunners[toolType],
-    toolType === "npm" || toolType === "pnpm"
+    toolType === "npm" || toolType === "pnpm" || toolType === "bun"
       ? ["install"]
       : toolType === "lerna"
         ? ["bootstrap", "--since", "HEAD"]

--- a/packages/find-root/README.md
+++ b/packages/find-root/README.md
@@ -1,6 +1,6 @@
 # @manypkg/find-root
 
-> Find the root of a monorepo with Yarn workspaces, npm, Lerna, pnpm or Rush
+> Find the root of a monorepo with Yarn workspaces, npm, Lerna, pnpm, Bun or Rush
 
 ## Install
 

--- a/packages/find-root/src/index.test.ts
+++ b/packages/find-root/src/index.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { findRoot, findRootSync } from "./index.ts";
 
 import {
+  BunTool,
   LernaTool,
   NpmTool,
   PnpmTool,
@@ -71,6 +72,40 @@ const runTests = (findRoot: FindRoot) => {
     expect(monorepoRoot).toEqual({
       tool: PnpmTool.type,
       rootDir: tmpPath,
+    });
+  });
+
+  test("it returns the root of a bun monorepo", async () => {
+    let tmpPath = f.copy("basic-bun");
+    let monorepoRoot = await findRoot(
+      path.join(tmpPath, "packages", "package-one", "src")
+    );
+    expect(monorepoRoot).toEqual({
+      tool: BunTool.type,
+      rootDir: tmpPath,
+    });
+  });
+
+  test("it returns the root of a bun monorepo with JSON lock file", async () => {
+    let tmpPath = f.copy("basic-bun-json-lock");
+    let monorepoRoot = await findRoot(
+      path.join(tmpPath, "packages", "package-one", "src")
+    );
+    expect(monorepoRoot).toEqual({
+      tool: BunTool.type,
+      rootDir: tmpPath,
+    });
+  });
+
+  test("it does not detect bun monorepo without lock file", async () => {
+    let tmpPath = f.copy("bun-no-lock");
+    let monorepoRoot = await findRoot(
+      path.join(tmpPath, "packages", "package-one", "src")
+    );
+    // Should be detected as a root tool since it has workspaces but no lock file
+    expect(monorepoRoot).toEqual({
+      tool: RootTool.type,
+      rootDir: path.join(tmpPath, "packages", "package-one"),
     });
   });
 

--- a/packages/find-root/src/index.ts
+++ b/packages/find-root/src/index.ts
@@ -1,4 +1,5 @@
 import {
+  BunTool,
   LernaTool,
   NpmTool,
   PnpmTool,
@@ -23,6 +24,7 @@ export const DEFAULT_TOOLS: Tool[] = [
   YarnTool,
   PnpmTool,
   NpmTool,
+  BunTool,
   LernaTool,
   RushTool,
   RootTool,

--- a/packages/get-packages/README.md
+++ b/packages/get-packages/README.md
@@ -1,8 +1,8 @@
 # @manypkg/get-packages
 
-> A simple utility to get the packages from a monorepo, whether they're using Yarn, npm, Lerna, pnpm or Rush
+> A simple utility to get the packages from a monorepo, whether they're using Yarn, npm, Lerna, pnpm, Bun or Rush
 
-This library exports `getPackages` and `getPackagesSync`. It is intended mostly for use of developers building tools that want to support different kinds of monorepos as an easy way to write tools without having to write tool-specific code. It supports Yarn, npm, Lerna, pnpm, Rush and single-package repos(where the only package is the the same as the root package). This library uses `@manypkg/find-root` to search up from the directory that's passed to `getPackages` or `getPackagesSync` to find the project root.
+This library exports `getPackages` and `getPackagesSync`. It is intended mostly for use of developers building tools that want to support different kinds of monorepos as an easy way to write tools without having to write tool-specific code. It supports Yarn, npm, Lerna, pnpm, Bun, Rush and single-package repos(where the only package is the the same as the root package). This library uses `@manypkg/find-root` to search up from the directory that's passed to `getPackages` or `getPackagesSync` to find the project root.
 
 ```typescript
 import { getPackages, getPackagesSync } from "@manypkg/get-packages";

--- a/packages/get-packages/src/index.test.ts
+++ b/packages/get-packages/src/index.test.ts
@@ -101,6 +101,46 @@ let runTests = (getPackages: GetPackages) => {
     expect(allPackages.tool.type).toEqual("pnpm");
   });
 
+  it("should resolve workspaces for bun", async () => {
+    const dir = f.copy("bun-workspace-base");
+
+    // Test for both root and subdirectories
+    for (const location of [".", "packages", "packages/pkg-a"]) {
+      const allPackages = await getPackages(path.join(dir, location));
+
+      if (allPackages.packages === null) {
+        return expect(allPackages.packages).not.toBeNull();
+      }
+
+      expect(allPackages.packages[0].packageJson.name).toEqual(
+        "bun-workspace-base-pkg-a"
+      );
+      expect(allPackages.packages[1].packageJson.name).toEqual(
+        "bun-workspace-base-pkg-b"
+      );
+      expect(allPackages.tool.type).toEqual("bun");
+    }
+  });
+
+  it("should resolve workspaces for bun with JSON lock file", async () => {
+    const dir = f.copy("basic-bun-json-lock");
+
+    // Test for both root and subdirectories
+    for (const location of [".", "packages", "packages/package-one"]) {
+      const allPackages = await getPackages(path.join(dir, location));
+
+      if (allPackages.packages === null) {
+        return expect(allPackages.packages).not.toBeNull();
+      }
+
+      expect(allPackages.packages[0].packageJson.name).toEqual(
+        "basic-bun-json-lock-package-one"
+      );
+      expect(allPackages.packages).toHaveLength(1);
+      expect(allPackages.tool.type).toEqual("bun");
+    }
+  });
+
   it("should resolve workspaces for lerna", async () => {
     const dir = f.copy("lerna-workspace-base");
 

--- a/packages/tools/src/BunTool.ts
+++ b/packages/tools/src/BunTool.ts
@@ -1,0 +1,151 @@
+import * as path from "node:path";
+import * as fs from "node:fs";
+import * as fsp from "node:fs/promises";
+import { F_OK } from "node:constants";
+
+import {
+  type Tool,
+  type PackageJSON,
+  type Packages,
+  InvalidMonorepoError,
+} from "./Tool.ts";
+import {
+  expandPackageGlobs,
+  expandPackageGlobsSync,
+} from "./expandPackageGlobs.ts";
+import { readJson, readJsonSync } from "./utils.ts";
+
+interface BunPackageJSON extends PackageJSON {
+  workspaces?: string[];
+}
+
+async function hasBunLockFile(directory: string): Promise<boolean> {
+  try {
+    await Promise.any([
+      fsp.access(path.join(directory, "bun.lockb"), F_OK),
+      fsp.access(path.join(directory, "bun.lock"), F_OK),
+    ]);
+    return true;
+  } catch (err) {
+    return false;
+  }
+}
+
+function hasBunLockFileSync(directory: string): boolean {
+  try {
+    fs.accessSync(path.join(directory, "bun.lockb"), F_OK);
+    return true;
+  } catch (err) {
+    try {
+      fs.accessSync(path.join(directory, "bun.lock"), F_OK);
+      return true;
+    } catch (err) {
+      return false;
+    }
+  }
+}
+
+export const BunTool: Tool = {
+  type: "bun",
+
+  async isMonorepoRoot(directory: string): Promise<boolean> {
+    try {
+      const [pkgJson, hasLockFile] = await Promise.all([
+        readJson(directory, "package.json") as Promise<BunPackageJSON>,
+        hasBunLockFile(directory),
+      ]);
+      if (pkgJson.workspaces && hasLockFile) {
+        if (Array.isArray(pkgJson.workspaces)) {
+          return true;
+        }
+      }
+    } catch (err) {
+      if (err && (err as { code: string }).code === "ENOENT") {
+        return false;
+      }
+      throw err;
+    }
+    return false;
+  },
+
+  isMonorepoRootSync(directory: string): boolean {
+    try {
+      const hasLockFile = hasBunLockFileSync(directory);
+      if (!hasLockFile) {
+        return false;
+      }
+      const pkgJson = readJsonSync(
+        directory,
+        "package.json"
+      ) as BunPackageJSON;
+      if (pkgJson.workspaces) {
+        if (Array.isArray(pkgJson.workspaces)) {
+          return true;
+        }
+      }
+    } catch (err) {
+      if (err && (err as { code: string }).code === "ENOENT") {
+        return false;
+      }
+      throw err;
+    }
+    return false;
+  },
+
+  async getPackages(directory: string): Promise<Packages> {
+    const rootDir = path.resolve(directory);
+
+    try {
+      const pkgJson = (await readJson(
+        rootDir,
+        "package.json"
+      )) as BunPackageJSON;
+      const packageGlobs: string[] = pkgJson.workspaces || [];
+
+      return {
+        tool: BunTool,
+        packages: await expandPackageGlobs(packageGlobs, rootDir),
+        rootPackage: {
+          dir: rootDir,
+          relativeDir: ".",
+          packageJson: pkgJson,
+        },
+        rootDir,
+      };
+    } catch (err) {
+      if (err && (err as { code: string }).code === "ENOENT") {
+        throw new InvalidMonorepoError(
+          `Directory ${rootDir} is not a valid ${BunTool.type} monorepo root`
+        );
+      }
+      throw err;
+    }
+  },
+
+  getPackagesSync(directory: string): Packages {
+    const rootDir = path.resolve(directory);
+
+    try {
+      const pkgJson = readJsonSync(rootDir, "package.json") as BunPackageJSON;
+      const packageGlobs: string[] = pkgJson.workspaces || [];
+
+      return {
+        tool: BunTool,
+        packages: expandPackageGlobsSync(packageGlobs, rootDir),
+        rootPackage: {
+          dir: rootDir,
+          relativeDir: ".",
+          packageJson: pkgJson,
+        },
+        rootDir,
+      };
+    } catch (err) {
+      if (err && (err as { code: string }).code === "ENOENT") {
+        throw new InvalidMonorepoError(
+          `Directory ${rootDir} is not a valid ${BunTool.type} monorepo root`
+        );
+      }
+      throw err;
+    }
+  },
+}; 

--- a/packages/tools/src/BunTool.ts
+++ b/packages/tools/src/BunTool.ts
@@ -74,10 +74,7 @@ export const BunTool: Tool = {
       if (!hasLockFile) {
         return false;
       }
-      const pkgJson = readJsonSync(
-        directory,
-        "package.json"
-      ) as BunPackageJSON;
+      const pkgJson = readJsonSync(directory, "package.json") as BunPackageJSON;
       if (pkgJson.workspaces) {
         if (Array.isArray(pkgJson.workspaces)) {
           return true;
@@ -148,4 +145,4 @@ export const BunTool: Tool = {
       throw err;
     }
   },
-}; 
+};

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./Tool.ts";
+export { BunTool } from "./BunTool.ts";
 export { LernaTool } from "./LernaTool.ts";
 export { NpmTool } from "./NpmTool.ts";
 export { PnpmTool } from "./PnpmTool.ts";


### PR DESCRIPTION
### ✨ Features

- **BunTool Implementation:**  
  Added a new `BunTool` for detecting and working with Bun-based monorepos.
- **Lockfile Support:**  
  Supports both `bun.lockb` (binary) and `bun.lock` (JSON) lockfile formats for Bun.
- **Monorepo Detection:**  
  Integrates Bun detection into the monorepo tool system, allowing Bun monorepos to be recognized alongside Yarn, npm, pnpm, Lerna, and Rush.
- **CLI Integration:**  
  Updates the CLI to handle Bun package management commands (e.g., `bun install`), ensuring commands like `manypkg check`, `manypkg fix`, and `manypkg run` work seamlessly in Bun monorepos.
- **Test Coverage:**  
  Adds comprehensive tests and fixtures for Bun monorepos, including detection, package resolution, and lockfile handling.

### 📝 Documentation

- Updates documentation and READMEs to mention Bun support.
- Adds a changeset entry describing the new feature.

### 🧪 Test Coverage

- Includes new and updated tests in `find-root` and `get-packages` to ensure Bun monorepos are correctly detected and handled.
- Ensures Bun support does not interfere with existing tool detection and workflows.

---
 
Please let me know if you have any feedback or suggestions!