### PR TITLE
docs: fixed incorrect docs section in `ROOT_HAS_PROD_DEPENDENCIES`

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ The root `package.json` of a monorepo is not published so whether a dependency i
 
 ### How it's fixed
 
-All `devDependencies` in the root `package.json` are moved to `dependencies`.
+All `dependencies` in the root `package.json` are moved to `devDependencies`.
 
 ## Multiple dependency types
 


### PR DESCRIPTION
Fixed inconsistency in docs in for the `ROOT_HAS_PROD_DEPENDENCIES` rule introduced in https://github.com/Thinkmill/manypkg/pull/236

Fixes #253 